### PR TITLE
Port filmmaking nodes and fixes from nodos-1.3

### DIFF
--- a/Include/nosMediaio/nosMediaIO.h
+++ b/Include/nosMediaio/nosMediaIO.h
@@ -162,6 +162,21 @@ typedef struct nosMediaIOVideoScanTypeList {
 	nosMediaIOVideoScanType ScanTypes[2];
 } nosMediaIOVideoScanTypeList;
 
+typedef enum nosMediaIOVideoConnectionType
+{
+	NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_INVALID,
+	NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_MIN = NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_INVALID,
+	NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_SDI,
+	NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_OPTICAL_ETHERNET,
+	NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_MAX = NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_OPTICAL_ETHERNET
+} nosMediaIOVideoConnectionType;
+
+inline const char* NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_NAMES[] = {
+	"INVALID",
+	"SDI",
+	"Optical Ethernet",
+};
+
 typedef enum nosMediaIOInterlacedFieldType
 {
 	NOS_MEDIAIO_INTERLACED_FIELD_TYPE_INVALID,
@@ -182,6 +197,8 @@ typedef struct nosMediaIOAPI {
 	nosResult (NOSAPI_CALL* Get2DFrameResolution)(nosMediaIOFrameGeometry geometry, nosVec2u* outResolution);
 	const char* (NOSAPI_CALL* GetVideoScanTypeName)(nosMediaIOVideoScanType scanType);
 	nosMediaIOVideoScanType (NOSAPI_CALL* GetVideoScanTypeFromString)(const char* str);
+	nosMediaIOVideoConnectionType (NOSAPI_CALL* GetVideoConnectionTypeFromString)(const char* str);
+	const char* (NOSAPI_CALL* GetVideoConnectionTypeName)(nosMediaIOVideoConnectionType connectionType);
 } nosMediaIOAPI;
 
 #pragma region Helper Declarations & Macros

--- a/Nodes/Conversions.nosnode
+++ b/Nodes/Conversions.nosnode
@@ -25,6 +25,23 @@
 						"can_show_as": "INPUT_PIN_ONLY"
 					},
 					{
+						"name": "GammaCurve",
+						"display name": "Gamma Curve",
+						"type_name": "nos.mediaio.GammaCurve",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "UseLUT",
+						"display name": "Use LUT",
+						"type_name": "bool",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"advanced_property": true,
+						"data": true,
+						"def": true
+					},
+					{
 						"name": "GammaLUT",
 						"type_name": "nos.sys.vulkan.Buffer",
 						"show_as": "INPUT_PIN",
@@ -111,6 +128,23 @@
 						"type_name": "nos.sys.vulkan.Buffer",
 						"show_as": "INPUT_PIN",
 						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "GammaCurve",
+						"display name": "Gamma Curve",
+						"type_name": "nos.mediaio.GammaCurve",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "UseLUT",
+						"display name": "Use LUT",
+						"type_name": "bool",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"advanced_property": true,
+						"data": true,
+						"def": true
 					},
 					{
 						"name": "GammaLUT",

--- a/Nodes/Conversions.nosnode
+++ b/Nodes/Conversions.nosnode
@@ -340,6 +340,153 @@
 			}
 		},
 		{
+			"class_name": "SLog3ToLinear",
+			"menu_info": {
+				"category": "Media IO|Conversions",
+				"display_name": "S-Log3 to Linear",
+				"name_aliases": [ "slog3", "s-log3", "log to linear", "decode log" ]
+			},
+			"node": {
+				"class_name": "SLog3ToLinear",
+				"contents_type": "Job",
+				"description": "Decodes Sony S-Log3 RGB to scene-linear RGB. Output is R16G16B16A16_SFLOAT to preserve sub-black and HDR highlights.",
+				"contents": {
+					"type": "nos.sys.vulkan.GPUNode",
+					"options": {
+						"shader": "Shaders/SLog3ToLinear.comp",
+						"stage": "COMPUTE"
+					}
+				},
+				"pins": [
+					{
+						"name": "Source",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "Output",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY"
+					},
+					{
+						"name": "DispatchSize",
+						"type_name": "nos.fb.vec2u",
+						"show_as": "PROPERTY",
+						"can_show_as": "PROPERTY_ONLY",
+						"data": {
+							"x": 120,
+							"y": 68
+						}
+					}
+				]
+			}
+		},
+		{
+			"class_name": "LinearToSLog3",
+			"menu_info": {
+				"category": "Media IO|Conversions",
+				"display_name": "Linear to S-Log3",
+				"name_aliases": [ "slog3", "s-log3", "linear to log", "encode log" ]
+			},
+			"node": {
+				"class_name": "LinearToSLog3",
+				"contents_type": "Job",
+				"description": "Encodes scene-linear RGB to Sony S-Log3. Output is R16G16B16A16_SFLOAT.",
+				"contents": {
+					"type": "nos.sys.vulkan.GPUNode",
+					"options": {
+						"shader": "Shaders/LinearToSLog3.comp",
+						"stage": "COMPUTE"
+					}
+				},
+				"pins": [
+					{
+						"name": "Source",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "Output",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY"
+					},
+					{
+						"name": "DispatchSize",
+						"type_name": "nos.fb.vec2u",
+						"show_as": "PROPERTY",
+						"can_show_as": "PROPERTY_ONLY",
+						"data": {
+							"x": 120,
+							"y": 68
+						}
+					}
+				]
+			}
+		},
+		{
+			"class_name": "TextureToBuffer",
+			"menu_info": {
+				"category": "Media IO|Conversions",
+				"display_name": "Texture To Buffer",
+				"name_aliases": [ "record format", "pack texture", "dpx pack", "rgb to buffer" ]
+			},
+			"node": {
+				"class_name": "TextureToBuffer",
+				"contents_type": "Job",
+				"description": "Encodes the input Texture with a transfer curve (Gamma LUT or analytic) and packs it\ninto the Output buffer in the chosen pixel format. RGB-only - no colorspace matrix and\nno interlacing. The Output buffer is host-visible so a download ring + Record Clip can\nread it back and write it to disk.",
+				"contents": {
+					"type": "nos.sys.vulkan.GPUNode",
+					"options": {
+						"shader": "Shaders/TextureToBuffer.comp",
+						"stage": "COMPUTE"
+					}
+				},
+				"pins": [
+					{
+						"name": "Source",
+						"type_name": "nos.sys.vulkan.Texture",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_ONLY"
+					},
+					{
+						"name": "GammaCurve",
+						"display_name": "Gamma Curve",
+						"type_name": "nos.mediaio.GammaCurve",
+						"show_as": "INPUT_PIN",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY"
+					},
+					{
+						"name": "OutputFormat",
+						"display_name": "Output Format",
+						"type_name": "nos.mediaio.RGBPixelFormat",
+						"show_as": "PROPERTY",
+						"can_show_as": "INPUT_PIN_OR_PROPERTY",
+						"data": "RGBA8"
+					},
+					{
+						"name": "DispatchSize",
+						"type_name": "nos.fb.vec2u",
+						"show_as": "PROPERTY",
+						"can_show_as": "PROPERTY_ONLY",
+						"data": {
+							"x": 120,
+							"y": 120
+						}
+					},
+					{
+						"name": "Output",
+						"type_name": "nos.sys.vulkan.Buffer",
+						"show_as": "OUTPUT_PIN",
+						"can_show_as": "OUTPUT_PIN_ONLY"
+					}
+				]
+			}
+		},
+		{
 			"class_name": "YUY2ToRGBA",
 			"menu_info": {
 				"category": "Media IO",

--- a/Nodes/ExtractTimecode.nosnode
+++ b/Nodes/ExtractTimecode.nosnode
@@ -1,0 +1,63 @@
+{
+    "nodes": [
+        {
+            "class_name": "ExtractTimecode",
+            "menu_info": {
+                "category": "Media IO|Timecode",
+                "display_name": "Extract Timecode"
+            },
+            "node": {
+                "class_name": "ExtractTimecode",
+                "display_name": "Extract Timecode",
+                "contents_type": "Job",
+                "description": "Decodes a SMPTE ST 12-2 Ancillary Timecode (ATC) packet from an ANCFrame and emits the decoded\nTimecode struct (HH:MM:SS:FF + drop-frame flag + ATC source) along with a Valid flag.\n\nFor SDI input via AJA, the AJA In node's Timecode output pin is the recommended source — the\nAJA hardware extracts RP188 ATC through its dedicated path. Use this node on ANCFrame data\nfrom non-AJA inputs (2110, file readers) or when you specifically need to decode an ATC packet\nthat reached you as ANC data.",
+              "pins": [
+                {
+                  "name": "Source",
+                  "display_name": "Source",
+                  "description": "ATC carriage to accept. Auto picks the highest-priority match (LTC > VITC1 > VITC2).\nExplicit selections (ATC_LTC / ATC_VITC1 / ATC_VITC2) reject other flavors.",
+                  "type_name": "nos.mediaio.ATCSource",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": 0
+                },
+                {
+                  "name": "FrameRateOverride",
+                  "display_name": "Frame Rate Override",
+                  "description": "Optional override for the frame rate used to validate the decoded frame field and decode HFR\n(>=40 fps) pair-encoded ATC packets. Leave at 0 to auto-infer from the executing path's\nfixed-step timing.",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": 0.0,
+                  "min": "0"
+                },
+                {
+                  "name": "Timecode",
+                  "display_name": "Timecode",
+                  "description": "Decoded SMPTE timecode. Only meaningful when Valid is true; left at its previous value when\nno matching ATC packet was found this tick.",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY"
+                },
+                {
+                  "name": "Valid",
+                  "display_name": "Valid",
+                  "description": "True if a matching, well-formed ATC packet was found and decoded this tick.",
+                  "type_name": "bool",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY"
+                },
+                {
+                  "name": "ANCFrame",
+                  "display_name": "ANC Frame",
+                  "description": "Input ANC frame to scan for ATC packets (DID=0x60, SDID=0x60).",
+                  "type_name": "nos.mediaio.ANCFrame",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY"
+                }
+              ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/InjectTimecode.nosnode
+++ b/Nodes/InjectTimecode.nosnode
@@ -1,0 +1,55 @@
+{
+    "nodes": [
+        {
+            "class_name": "InjectTimecode",
+            "menu_info": {
+                "category": "Media IO|Timecode",
+                "display_name": "Inject Timecode"
+            },
+            "node": {
+                "class_name": "InjectTimecode",
+                "display_name": "Inject Timecode",
+                "contents_type": "Job",
+                "always_execute": true,
+                "description": "Encodes a SMPTE ST 12-2 Ancillary Timecode (ATC) packet from a decoded Timecode struct and\ninjects it into an ANCFrame. Existing ATC packets matching the same flavor (LTC/VITC1/VITC2)\non the same field are stripped and replaced; all other packets pass through unchanged. If the\ninput ANCFrame is empty or unset, a fresh ANCFrame containing only the encoded ATC packet is\nproduced.\n\nFor SDI output via AJA, prefer wiring Timecode directly into the AJA Out node's Timecode pin\n— the AJA hardware drives RP188 ATC through the dedicated emitter and the inserter path is\nfor vendor packets. Use this node for non-AJA outputs (2110, file writers) or when you need\nthe ATC packet as data inside an ANCFrame.",
+              "pins": [
+                {
+                  "name": "Timecode",
+                  "display_name": "Timecode",
+                  "description": "Decoded SMPTE timecode to encode into a SMPTE ST 12-2 ATC packet (DID=0x60, SDID=0x60). The\ntimecode's source field selects ATC carriage (LTC / VITC1 / VITC2); Auto is treated as ATC_LTC.",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY"
+                },
+                {
+                  "name": "FrameRateOverride",
+                  "display_name": "Frame Rate Override",
+                  "description": "Optional override for the frame rate used to select the HFR (>=40 fps) field-bit encoding and\nthe PAL/NTSC family. Leave at 0 to auto-infer from the executing path's fixed-step timing.",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": 0.0,
+                  "min": "0"
+                },
+                {
+                  "name": "Out",
+                  "display_name": "Out",
+                  "description": "Output ANC frame with the encoded ATC packet appended at VANC line 10, channel Y, link A.",
+                  "type_name": "nos.mediaio.ANCFrame",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY"
+                },
+                {
+                  "name": "ANCFrame",
+                  "display_name": "ANC Frame",
+                  "description": "Optional source ANC frame. Packets other than the selected ATC flavor on the same field are\nforwarded verbatim. Leave unconnected to emit a fresh frame containing only the timecode packet.",
+                  "type_name": "nos.mediaio.ANCFrame",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY"
+                }
+              ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/Interlace.nosnode
+++ b/Nodes/Interlace.nosnode
@@ -2,6 +2,7 @@
 	"nodes": [
 		{
 			"class_name": "Interlace",
+			"hide_in_context_menu": true,
 			"menu_info": {
 				"category": "Media IO",
 				"display_name": "Interlace"
@@ -29,6 +30,7 @@
 		},
 		{
 			"class_name": "Deinterlace",
+			"hide_in_context_menu": true,
 			"menu_info": {
 				"category": "Media IO",
 				"display_name": "Deinterlace"

--- a/Nodes/PlaybackClip.nosnode
+++ b/Nodes/PlaybackClip.nosnode
@@ -1,0 +1,47 @@
+{
+    "nodes": [
+        {
+            "class_name": "PlaybackClip",
+            "menu_info": {
+                "category": "Media IO|Recording",
+                "display_name": "Playback Clip",
+                "name_aliases": [ "play texture", "texture playback", "play clip" ]
+            },
+            "node": {
+                "class_name": "PlaybackClip",
+                "display_name": "Playback Clip",
+                "contents_type": "Job",
+                "always_execute": true,
+                "description": "Plays back an uncompressed DPX sequence recorded by Record Clip. For the incoming\nTimecode it loads the matching 'HH-MM-SS-FF.dpx' frame from Path and emits it on the\nTexture output. When no frame matches the timecode, the last loaded frame is held.",
+                "pins": [
+                    {
+                        "name": "Timecode",
+                        "display_name": "Timecode",
+                        "description": "SMPTE timecode to look up. Selects the frame 'HH-MM-SS-FF.dpx' under Path.",
+                        "type_name": "nos.mediaio.Timecode",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY"
+                    },
+                    {
+                        "name": "Path",
+                        "display_name": "Path",
+                        "description": "Directory containing the .dpx frame sequence written by Record Clip.",
+                        "type_name": "string",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": { "type": "FOLDER_PICKER" }
+                    },
+                    {
+                        "name": "Texture",
+                        "display_name": "Texture",
+                        "description": "Decoded frame for the current timecode. Holds the previous frame when the file is\nmissing or fails to load.",
+                        "type_name": "nos.sys.vulkan.Texture",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY"
+                    }
+                ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/RecordDPXClip.nosnode
+++ b/Nodes/RecordDPXClip.nosnode
@@ -1,0 +1,1994 @@
+{
+  "nodes": [
+    {
+      "class_name": "nos.mediaio.RecordDPXClip",
+      "menu_info": {
+        "category": "Media IO|Recording",
+        "display_name": "Record DPX Clip",
+        "name_aliases": [
+          "record clip",
+          "record buffer",
+          "buffer recorder",
+          "capture clip",
+          "dpx writer",
+          "dpx sequence"
+        ]
+      },
+      "node": {
+        "id": "747e587b-84d7-4843-927e-0ea4994a637c",
+        "name": "RecordDPXClip",
+        "class_name": "nos.mediaio.RecordDPXClip",
+        "pins": [
+          {
+            "id": "9f66c060-2e6d-4f31-81a0-40ebc8517a9b",
+            "name": "Thread",
+            "type_name": "nos.exe",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_ONLY",
+            "visualizer": {},
+            "data": {},
+            "def": {},
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "c0ba385a-37e4-4d41-adcf-924364510da3"
+            }
+          },
+          {
+            "id": "9a207f25-3715-4070-b16c-720210b447f8",
+            "name": "Input_B",
+            "type_name": "nos.mediaio.Timecode",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_ONLY",
+            "visualizer": {},
+            "data": {
+              "hours": 0,
+              "minutes": 0,
+              "seconds": 15,
+              "frames": 0,
+              "drop_frame": false,
+              "source": "ATC_LTC"
+            },
+            "min": {
+              "hours": 0,
+              "minutes": 0,
+              "seconds": 0,
+              "frames": 0,
+              "drop_frame": false,
+              "source": "Auto"
+            },
+            "max": {
+              "hours": 0,
+              "minutes": 0,
+              "seconds": 0,
+              "frames": 0,
+              "drop_frame": false,
+              "source": "Auto"
+            },
+            "def": {
+              "hours": 0,
+              "minutes": 0,
+              "seconds": 0,
+              "frames": 0,
+              "drop_frame": false,
+              "source": "Auto"
+            },
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "590f5ef6-2483-48a8-9ec4-62cd117602e6"
+            },
+            "display_name": "Timecode"
+          },
+          {
+            "id": "74be8797-c11f-4f52-99a0-dc171279562e",
+            "name": "Input_C",
+            "type_name": "bool",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_ONLY",
+            "visualizer": {},
+            "data": false,
+            "def": false,
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "b08ebd74-85ba-47f0-afe1-714c890cba48"
+            },
+            "display_name": "Write"
+          },
+          {
+            "id": "032cd411-1f61-4950-b64a-70863f0a19c1",
+            "name": "GammaCurve",
+            "type_name": "nos.mediaio.GammaCurve",
+            "show_as": "PROPERTY",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {},
+            "data": "REC709",
+            "min": "REC709",
+            "max": "REC709",
+            "def": "REC709",
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "d3153fef-b28f-4880-beb0-c01ebdc2f833"
+            },
+            "display_name": "Gamma Curve"
+          },
+          {
+            "id": "778a6149-307a-47e7-91cc-d42e741d41f3",
+            "name": "OutputFormat",
+            "type_name": "nos.mediaio.RGBPixelFormat",
+            "show_as": "PROPERTY",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {},
+            "data": "RGBA8",
+            "min": "RGBA8",
+            "max": "RGBA8",
+            "def": "RGBA8",
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "d4308822-3e65-4983-a3ee-9e98a4406f1f"
+            },
+            "display_name": "Output Format"
+          },
+          {
+            "id": "7a91f2c4-21f4-4795-8f7a-26ebeb9fe0db",
+            "name": "Size",
+            "type_name": "uint",
+            "show_as": "PROPERTY",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {},
+            "data": 2,
+            "min": 1,
+            "max": 120,
+            "def": 2,
+            "step": 1.19,
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "e69b410b-61c1-4f37-8a7c-4e8b7b79788b"
+            }
+          },
+          {
+            "id": "7a4df95e-f8ee-48cb-90c5-0dbdb20f7cf6",
+            "name": "Input (1)",
+            "type_name": "nos.sys.vulkan.Texture",
+            "show_as": "INPUT_PIN",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {},
+            "data": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+            },
+            "def": {
+              "resolution": "HD",
+              "width": 1920,
+              "height": 1080,
+              "format": "R16G16B16A16_SFLOAT",
+              "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+            },
+            "advanced_property": true,
+            "meta_data_map": [
+              {
+                "key": "AdvancedProperty",
+                "value": "true"
+              }
+            ],
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "e653fa81-87cb-4774-927f-9cd14472ed2d"
+            }
+          },
+          {
+            "id": "0c0a21cc-2fc1-457a-a502-5ac2a887bed9",
+            "name": "Path",
+            "type_name": "string",
+            "show_as": "PROPERTY",
+            "can_show_as": "INPUT_PIN_OR_PROPERTY",
+            "visualizer": {
+              "type": "FOLDER_PICKER"
+            },
+            "data": "",
+            "def": "",
+            "contents_type": "PortalPin",
+            "contents": {
+              "source_id": "cd2bfabc-ea96-4b58-8ac4-bfe2198719df"
+            },
+            "description": "Output directory for the recorded .dpx sequence. Created if it does not exist.",
+            "display_name": "Path"
+          }
+        ],
+        "pos": {
+          "x": 0.0,
+          "y": 0.0
+        },
+        "contents_type": "Graph",
+        "contents": {
+          "nodes": [
+            {
+              "id": "7ad5abb8-947f-4165-8def-18fa275eb586",
+              "name": "Make (1)",
+              "class_name": "nos.reflect.MakeDynamic",
+              "pins": [
+                {
+                  "id": "878411e8-a605-458a-bd72-a8045c825a98",
+                  "name": "Output",
+                  "type_name": "nos.fb.vec2u",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "x": 1920,
+                    "y": 1080
+                  },
+                  "def": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "connection_conditions": "!array"
+                },
+                {
+                  "id": "9d9530d2-f21a-4e57-906d-ddd49d3c5aa3",
+                  "name": "x",
+                  "type_name": "uint",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 1920,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "52b68182-6518-439d-8a09-7da064cca63e",
+                  "name": "y",
+                  "type_name": "uint",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 1080,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                }
+              ],
+              "pos": {
+                "x": -237.0,
+                "y": 335.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "template_parameters": [
+                {
+                  "name": "Type",
+                  "type_name": "string",
+                  "value": "nos.fb.vec2u"
+                }
+              ],
+              "plugin_version": {
+                "major": 1,
+                "minor": 7,
+                "patch": 16
+              }
+            },
+            {
+              "id": "45c9191b-d257-48b0-b422-5869868c76bb",
+              "name": "Thread (1)",
+              "class_name": "nos.Thread",
+              "always_execute": true,
+              "pins": [
+                {
+                  "id": "3a202e12-322d-4634-8f78-10be923ddcb4",
+                  "name": "Run",
+                  "type_name": "nos.exe",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "def": {},
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "c3b0b9b1-8a60-47d0-9516-36a83d5ed6c4",
+                  "name": "Importance",
+                  "type_name": "ulong",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "PROPERTY_ONLY",
+                  "visualizer": {},
+                  "data": 0,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                }
+              ],
+              "pos": {
+                "x": 235.0,
+                "y": -125.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            },
+            {
+              "id": "292b9ca8-6ad1-4794-b352-d5c012b37306",
+              "name": "OutputFormat",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "49db87e8-0bb5-4ea5-bffa-85767db7c5d3",
+                  "name": "Output",
+                  "type_name": "nos.mediaio.RGBPixelFormat",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": "RGBA8",
+                  "min": "RGBA8",
+                  "max": "RGBA8",
+                  "def": "RGBA8",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Output Format"
+                },
+                {
+                  "id": "d4308822-3e65-4983-a3ee-9e98a4406f1f",
+                  "name": "Input",
+                  "type_name": "nos.mediaio.RGBPixelFormat",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "RGBA8",
+                  "referred_by": [
+                    "778a6149-307a-47e7-91cc-d42e741d41f3"
+                  ],
+                  "min": "RGBA8",
+                  "max": "RGBA8",
+                  "def": "RGBA8",
+                  "meta_data_map": [
+                    {
+                      "key": "PinHidden",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Output Format"
+                }
+              ],
+              "pos": {
+                "x": -551.0,
+                "y": 227.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            },
+            {
+              "id": "2f874294-c5f0-4331-961c-8383425d6a1c",
+              "name": "Size",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "e6b09200-ad71-464b-8eb0-6bb74702bca2",
+                  "name": "Output",
+                  "type_name": "uint",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": 2,
+                  "min": 1,
+                  "max": 120,
+                  "def": 2,
+                  "step": 1.19,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "e69b410b-61c1-4f37-8a7c-4e8b7b79788b",
+                  "name": "Input",
+                  "type_name": "uint",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 2,
+                  "referred_by": [
+                    "7a91f2c4-21f4-4795-8f7a-26ebeb9fe0db"
+                  ],
+                  "min": 1,
+                  "max": 120,
+                  "def": 2,
+                  "step": 1.19,
+                  "meta_data_map": [
+                    {
+                      "key": "PinHidden",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {}
+                }
+              ],
+              "pos": {
+                "x": -27.0,
+                "y": 55.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "display_name": "Ring Size",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            },
+            {
+              "id": "a321cb28-0ef4-4373-90ff-34c690e6601e",
+              "name": "ScheduleRequest",
+              "class_name": "nos.utilities.ScheduleRequest",
+              "pins": [
+                {
+                  "id": "8d765d04-9bbf-44a0-a3ac-c50f5566919e",
+                  "name": "Trigger",
+                  "type_name": "nos.exe",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "def": {},
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "24073d66-733d-4933-9607-756d38a818d7",
+                  "name": "Sink",
+                  "type_name": "nos.Generic",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "def": {},
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "57c58e8a-3c93-43b8-814a-5ce881d5404a",
+                  "name": "DeltaSeconds",
+                  "type_name": "nos.fb.vec2u",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": {
+                    "x": 1,
+                    "y": 50
+                  },
+                  "def": {
+                    "x": 1,
+                    "y": 60
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Target time between path runs, as a rational x/y seconds. Default 1/60.",
+                  "display_name": "Delta Seconds"
+                },
+                {
+                  "id": "c6ec871a-c4a3-4fcc-a9db-bb87327a7451",
+                  "name": "Mode",
+                  "type_name": "nos.utilities.ScheduleRequestMode",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "FixedStep",
+                  "min": "Continuous",
+                  "max": "Continuous",
+                  "def": "Continuous",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Continuous queues a request each run and lets the engine pace the path.\nFixedStep busy-waits so the path fires at even DeltaSeconds intervals,\nabsorbing upstream execution time instead of adding it to the interval."
+                },
+                {
+                  "id": "c46cad2e-8a5d-435f-8f5c-64cd2e36fab1",
+                  "name": "MaxWaitSeconds",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 1.0,
+                  "def": 1.0,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Safety cap on how long a single FixedStep run may block, so a bad\nDelta Seconds can't stall the engine thread. 0 disables the cap.",
+                  "display_name": "Max Wait Seconds"
+                },
+                {
+                  "id": "ed85771b-a63f-43ae-9517-e8ccf1e42c69",
+                  "name": "Importance",
+                  "type_name": "uint",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 1,
+                  "def": 1,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Conflicting paths are controlled by the node of higher importance."
+                },
+                {
+                  "id": "47772ee1-081a-4769-996e-5842caea5382",
+                  "name": "TryAgainOnFailure",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": true,
+                  "def": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "If enabled, the request is retried when a node on the path returns an error.",
+                  "display_name": "Try Again On Failure"
+                }
+              ],
+              "pos": {
+                "x": 900.0,
+                "y": 6.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "status_messages": [
+                {
+                  "text": "Mode: Fixed Step"
+                },
+                {
+                  "text": "Delta Seconds: 1/50"
+                },
+                {
+                  "text": "Drop Count: 3",
+                  "type": "WARNING"
+                }
+              ],
+              "description": "Drives an on-demand path. Each execution, and each path start, queues another\nschedule request so the path feeding Trigger keeps running. Wire the resource you\nwant scheduled into Sink.",
+              "display_name": "Schedule Request",
+              "plugin_version": {
+                "major": 3,
+                "minor": 15,
+                "patch": 0
+              }
+            },
+            {
+              "id": "b8d14fb9-5727-457a-81f0-0ea766bd9557",
+              "name": "WriteDPX",
+              "class_name": "nos.mediaio.WriteDPX",
+              "pins": [
+                {
+                  "id": "9fbc2858-ee68-4cd7-bb7a-b025151a6b7b",
+                  "name": "InExe",
+                  "type_name": "nos.exe",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "def": {},
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "d1936339-9722-4b17-b15a-905817e8bf1c",
+                  "name": "OutExe",
+                  "type_name": "nos.exe",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "def": {},
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "a69742c2-655f-4062-bd57-d648057cb508",
+                  "name": "Buffer",
+                  "type_name": "nos.sys.vulkan.Buffer",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "size_in_bytes": 8294400,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 2
+                    },
+                    "usage": "TRANSFER_SRC TRANSFER_DST STORAGE_BUFFER",
+                    "memory_flags": "HOST_VISIBLE DOWNLOAD",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "def": {
+                    "size_in_bytes": 0,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 0
+                    },
+                    "usage": "NONE",
+                    "memory_flags": "NONE",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Host-visible buffer of packed pixels to record, from a Texture To Buffer node via a\ndownload ring. Written to disk verbatim after the DPX header.",
+                  "display_name": "Buffer"
+                },
+                {
+                  "id": "9e129a4f-9429-48a9-bd3e-6effe8b17c07",
+                  "name": "Timecode",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 15,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "ATC_LTC"
+                  },
+                  "def": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "SMPTE timecode for the current frame. Names the file 'HH-MM-SS-FF.dpx' and is\nembedded in the DPX header.",
+                  "display_name": "Timecode"
+                },
+                {
+                  "id": "cd2bfabc-ea96-4b58-8ac4-bfe2198719df",
+                  "name": "Path",
+                  "type_name": "string",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {
+                    "type": "FOLDER_PICKER"
+                  },
+                  "data": "",
+                  "referred_by": [
+                    "0c0a21cc-2fc1-457a-a502-5ac2a887bed9"
+                  ],
+                  "def": "",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Output directory for the recorded .dpx sequence. Created if it does not exist.",
+                  "display_name": "Path"
+                },
+                {
+                  "id": "2e9a799b-d4e3-4273-9fe4-473274418b14",
+                  "name": "Write",
+                  "type_name": "bool",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": false,
+                  "def": false,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "While true, every executed frame is written to disk. While false, nothing is written.",
+                  "display_name": "Write"
+                },
+                {
+                  "id": "874550cd-2d7b-4896-ada6-66efe6febc79",
+                  "name": "Resolution",
+                  "type_name": "nos.fb.vec2u",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": {
+                    "x": 1920,
+                    "y": 1080
+                  },
+                  "def": {
+                    "x": 1920,
+                    "y": 1080
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Frame size of the buffer in pixels. Must match the texture the Texture To Buffer\nnode packed; drives the DPX header and how many bytes are written.",
+                  "display_name": "Resolution"
+                },
+                {
+                  "id": "484df806-e253-4997-ad3b-b580d13b44b7",
+                  "name": "OutputFormat",
+                  "type_name": "nos.mediaio.RGBPixelFormat",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "RGBA8",
+                  "def": "RGBA8",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Packed pixel layout of the buffer. Must match the Texture To Buffer node's Output\nFormat: RGBA8 / RGBA16 / RGB10 (DPX Method A) / RGB8.",
+                  "display_name": "Output Format"
+                },
+                {
+                  "id": "2d2ff8a1-4e2d-474e-9c20-37c189e54604",
+                  "name": "Transfer",
+                  "type_name": "nos.mediaio.GammaCurve",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "REC709",
+                  "def": "SRGB",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Transfer curve the buffer was encoded with upstream, recorded in the DPX header's\ntransfer characteristic. IDENTITY -> linear, REC709 -> CCIR 709; other curves are\ntagged user-defined.",
+                  "display_name": "Transfer"
+                }
+              ],
+              "pos": {
+                "x": 569.0,
+                "y": 47.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "status_messages": [
+                {
+                  "text": "Idle"
+                }
+              ],
+              "description": "Writes the input Buffer to disk as an uncompressed DPX sequence while Write is true.\nEach execution writes a 'HH-MM-SS-FF.dpx' file - named from and with the SMPTE timecode\nembedded in its header - under Path. The pixels are produced upstream by a Texture To\nBuffer node (encoding + packing) and made host-visible by a download ring, so this node\ndoes no GPU work: it maps the buffer and writes the bytes. Resolution, Output Format and\nTransfer describe the buffer for the DPX header and must match the Texture To Buffer node.\nDrive it through the In/Out exe pins to schedule it. Play the result back with the\nPlayback Clip node.",
+              "display_name": "Write DPX",
+              "plugin_version": {
+                "major": 2,
+                "minor": 9,
+                "patch": 0
+              }
+            },
+            {
+              "id": "0fb60342-26e8-4a82-93c3-35aa574c444d",
+              "name": "Input (1)",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "f1e95345-21af-43d7-8441-8f5781eeb6da",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    {
+                      "key": "AdvancedProperty",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "e653fa81-87cb-4774-927f-9cd14472ed2d",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "referred_by": [
+                    "7a4df95e-f8ee-48cb-90c5-0dbdb20f7cf6"
+                  ],
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    {
+                      "key": "AdvancedProperty",
+                      "value": "true"
+                    },
+                    {
+                      "key": "PinHidden",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {}
+                }
+              ],
+              "pos": {
+                "x": -720.0,
+                "y": 410.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "display_name": "Input",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            },
+            {
+              "id": "2a3710e8-59bc-4330-a98a-e013a790f73f",
+              "name": "Break",
+              "class_name": "nos.reflect.Break",
+              "pins": [
+                {
+                  "id": "22008ed1-f58a-42e4-becb-faa1eb17cdb4",
+                  "name": "Input",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "fef22e56-129d-4d5d-995c-6beec418141b",
+                  "name": "handle",
+                  "type_name": "ulong",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 1943401881360,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "10e52c00-9aac-4d55-a322-ea0cd31d8f1f",
+                  "name": "offset",
+                  "type_name": "ulong",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 0,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "ff6276e6-e7b2-4a28-be55-97a42f2bd3a9",
+                  "name": "size_in_bytes",
+                  "type_name": "ulong",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 17694720,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "97ebd28c-db15-4ca3-af35-99c2cd4f72bf",
+                  "name": "external_memory",
+                  "type_name": "nos.sys.vulkan.ExternalMemory",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": {
+                    "handle_type": 2
+                  },
+                  "def": {
+                    "handle_type": 0
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "c0196295-f6df-4d1b-bc18-889244329258",
+                  "name": "resolution",
+                  "type_name": "nos.sys.vulkan.SizePreset",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "HD",
+                  "def": "CUSTOM",
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "8e8ebb04-cccb-4d30-bbc7-15605e1c5041",
+                  "name": "width",
+                  "type_name": "uint",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 1920,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "0058db9b-5614-47b5-adb3-aff63eb72092",
+                  "name": "height",
+                  "type_name": "uint",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 1080,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "574025f9-ef9a-434e-88bd-aa139f1977a3",
+                  "name": "format",
+                  "type_name": "nos.sys.vulkan.Format",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "R16G16B16A16_SFLOAT",
+                  "def": "NONE",
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "22a491f7-8807-42a1-85e1-c034fc7247cf",
+                  "name": "usage",
+                  "type_name": "nos.sys.vulkan.ImageUsage",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET",
+                  "def": "NONE",
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "1a2a983b-a7d0-4a07-91b2-93f2c8f2887b",
+                  "name": "filtering",
+                  "type_name": "nos.sys.vulkan.Filtering",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "NEAREST",
+                  "def": "NEAREST",
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "8509aefc-dcd3-4944-8388-19c49c62a8f2",
+                  "name": "unscaled",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": false,
+                  "def": false,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "4d492923-25c3-4bef-877b-60ae5b74b6b0",
+                  "name": "unmanaged",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": false,
+                  "def": false,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "b0465295-81ae-489d-80d3-4906d972d805",
+                  "name": "field_type",
+                  "type_name": "nos.sys.vulkan.FieldType",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "PROGRESSIVE",
+                  "def": "PROGRESSIVE",
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "106a965c-b874-4f9a-9eb9-a75080d569a9",
+                  "name": "stock_texture",
+                  "type_name": "nos.sys.vulkan.StockTexture",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "OUTPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "NOSNOVIDEO",
+                  "def": "NOSNOVIDEO",
+                  "contents_type": "JobPin",
+                  "contents": {}
+                }
+              ],
+              "pos": {
+                "x": -474.0,
+                "y": 335.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "display_name": "Break nos.sys.vulkan.Texture",
+              "plugin_version": {
+                "major": 1,
+                "minor": 7,
+                "patch": 16
+              }
+            },
+            {
+              "id": "aa3c64a4-5ea1-40a5-a669-a2bfdffe47e5",
+              "name": "GammaCurve",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "603958c6-4e9d-4e5b-9c37-1da94cbd14da",
+                  "name": "Output",
+                  "type_name": "nos.mediaio.GammaCurve",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": "REC709",
+                  "min": "REC709",
+                  "max": "REC709",
+                  "def": "REC709",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Gamma Curve"
+                },
+                {
+                  "id": "d3153fef-b28f-4880-beb0-c01ebdc2f833",
+                  "name": "Input",
+                  "type_name": "nos.mediaio.GammaCurve",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "REC709",
+                  "referred_by": [
+                    "032cd411-1f61-4950-b64a-70863f0a19c1"
+                  ],
+                  "min": "REC709",
+                  "max": "REC709",
+                  "def": "REC709",
+                  "meta_data_map": [
+                    {
+                      "key": "PinHidden",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Gamma Curve"
+                }
+              ],
+              "pos": {
+                "x": -548.0,
+                "y": 172.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            },
+            {
+              "id": "fecafc51-8d6b-4b59-9490-a3653303d799",
+              "name": "TextureToBuffer",
+              "class_name": "nos.mediaio.TextureToBuffer",
+              "pins": [
+                {
+                  "id": "d5c574a8-9d47-4b59-aa9f-75e4612b6eb5",
+                  "name": "Source",
+                  "type_name": "nos.sys.vulkan.Texture",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "def": {
+                    "resolution": "HD",
+                    "width": 1920,
+                    "height": 1080,
+                    "format": "R16G16B16A16_SFLOAT",
+                    "usage": "TRANSFER_SRC TRANSFER_DST SAMPLED STORAGE RENDER_TARGET"
+                  },
+                  "advanced_property": true,
+                  "meta_data_map": [
+                    {
+                      "key": "AdvancedProperty",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "13f9d47a-1b19-49ee-bed2-4ea249e7cfd4",
+                  "name": "GammaCurve",
+                  "type_name": "nos.mediaio.GammaCurve",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "REC709",
+                  "min": "REC709",
+                  "max": "REC709",
+                  "def": "REC709",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Gamma Curve"
+                },
+                {
+                  "id": "decf34ce-1888-48c0-874e-c63c2b897f61",
+                  "name": "OutputFormat",
+                  "type_name": "nos.mediaio.RGBPixelFormat",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": "RGBA8",
+                  "min": "RGBA8",
+                  "max": "RGBA8",
+                  "def": "RGBA8",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Output Format"
+                },
+                {
+                  "id": "41220b14-2c78-4f64-97dd-49cb58bf6bb6",
+                  "name": "DispatchSize",
+                  "type_name": "nos.fb.vec2u",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "PROPERTY_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "x": 120,
+                    "y": 68
+                  },
+                  "def": {
+                    "x": 120,
+                    "y": 120
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "b9700c31-bded-4f6c-bf5e-158dc2ec60ea",
+                  "name": "Output",
+                  "type_name": "nos.sys.vulkan.Buffer",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "size_in_bytes": 8294400,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 2
+                    },
+                    "usage": "TRANSFER_SRC STORAGE_BUFFER",
+                    "memory_flags": "HOST_VISIBLE DOWNLOAD",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "def": {
+                    "size_in_bytes": 0,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 0
+                    },
+                    "usage": "NONE",
+                    "memory_flags": "NONE",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {}
+                }
+              ],
+              "pos": {
+                "x": -81.0,
+                "y": 456.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": "nos.sys.vulkan.GPUNode",
+                "options": {
+                  "shader": "Shaders/TextureToBuffer.comp",
+                  "stage": "COMPUTE"
+                }
+              },
+              "function_category": "Default Node",
+              "description": "Encodes the input Texture with a transfer curve (Gamma LUT or analytic) and packs it\ninto the Output buffer in the chosen pixel format. RGB-only - no colorspace matrix and\nno interlacing. The Output buffer is host-visible so a download ring + Record Clip can\nread it back and write it to disk.",
+              "plugin_version": {
+                "major": 2,
+                "minor": 9,
+                "patch": 0
+              }
+            },
+            {
+              "id": "fdf24388-2e9d-44ae-b8b8-feab47b2b356",
+              "name": "MultiRingBuffer",
+              "class_name": "nos.utilities.MultiRingBuffer",
+              "pins": [
+                {
+                  "id": "98add52e-2caa-4828-9d73-a130277e2e7c",
+                  "name": "Thread",
+                  "type_name": "nos.exe",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "def": {},
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "a47e137e-01ed-425c-a413-6a4aee711bdb",
+                  "name": "Size",
+                  "type_name": "uint",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 2,
+                  "min": 1,
+                  "max": 120,
+                  "def": 2,
+                  "step": 1.19,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "9113267a-e50f-4175-a690-61352684a25c",
+                  "name": "Spare",
+                  "type_name": "uint",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 0,
+                  "min": 0,
+                  "max": 119,
+                  "def": 0,
+                  "step": 1.19,
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "4c708db0-34ba-461e-af71-40e2645cf47e",
+                  "name": "Alignment",
+                  "type_name": "uint",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": 0,
+                  "def": 0,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Used for creating memory-aligned buffers in memory"
+                },
+                {
+                  "id": "b09c8a4e-2162-4188-a66d-f6c231947a69",
+                  "name": "Input_A",
+                  "type_name": "nos.sys.vulkan.Buffer",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "size_in_bytes": 8294400,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 2
+                    },
+                    "usage": "TRANSFER_SRC STORAGE_BUFFER",
+                    "memory_flags": "HOST_VISIBLE DOWNLOAD",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "def": {
+                    "size_in_bytes": 0,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 0
+                    },
+                    "usage": "NONE",
+                    "memory_flags": "NONE",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Buffer"
+                },
+                {
+                  "id": "cc8732f1-00c8-4cbd-b72d-00f7164d0f5b",
+                  "name": "Output_A",
+                  "type_name": "nos.sys.vulkan.Buffer",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "size_in_bytes": 8294400,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 2
+                    },
+                    "usage": "TRANSFER_SRC TRANSFER_DST STORAGE_BUFFER",
+                    "memory_flags": "HOST_VISIBLE DOWNLOAD",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "def": {
+                    "size_in_bytes": 0,
+                    "alignment": 0,
+                    "external_memory": {
+                      "handle_type": 0
+                    },
+                    "usage": "NONE",
+                    "memory_flags": "NONE",
+                    "element_type": "ELEMENT_TYPE_UNDEFINED"
+                  },
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Buffer"
+                },
+                {
+                  "id": "26deea26-1da6-4ddd-a4d3-1f21753e1d18",
+                  "name": "RepeatWhenFilling",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "visualizer": {},
+                  "data": true,
+                  "def": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "description": "Serves the last value while the buffer is being filled instead of waiting & resets the ring on restart",
+                  "display_name": "Repeat When Filling"
+                },
+                {
+                  "id": "e7d940c2-7181-40d8-b1d5-144f0dfb5673",
+                  "name": "Input_B",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 15,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "ATC_LTC"
+                  },
+                  "min": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "max": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "def": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Timecode"
+                },
+                {
+                  "id": "1d5886e8-4303-4a2b-9695-9cc030eda6cf",
+                  "name": "Output_B",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 15,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "ATC_LTC"
+                  },
+                  "min": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "max": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "def": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Timecode"
+                },
+                {
+                  "id": "0a0058c3-b36e-4879-a181-7e2cf367584f",
+                  "name": "Input_C",
+                  "type_name": "bool",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": false,
+                  "def": false,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Write"
+                },
+                {
+                  "id": "e20d73a9-315d-40bf-9dd9-f5893155cd6d",
+                  "name": "Output_C",
+                  "type_name": "bool",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": false,
+                  "def": false,
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Write"
+                },
+                {
+                  "id": "1e011fb8-c8ce-410c-99d9-06d777a6a44f",
+                  "name": "Input_D",
+                  "type_name": "nos.fb.vec2u",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "x": 1920,
+                    "y": 1080
+                  },
+                  "def": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Resolution"
+                },
+                {
+                  "id": "e5965779-359a-447d-b478-567c2066a658",
+                  "name": "Output_D",
+                  "type_name": "nos.fb.vec2u",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "x": 1920,
+                    "y": 1080
+                  },
+                  "def": {
+                    "x": 0,
+                    "y": 0
+                  },
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Resolution"
+                },
+                {
+                  "id": "5c475308-2e3e-4c6a-b4ff-e29dc32bd65f",
+                  "name": "Input_E",
+                  "type_name": "nos.mediaio.RGBPixelFormat",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": "RGBA8",
+                  "def": "RGBA8",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Output Format"
+                },
+                {
+                  "id": "b4aef3b5-f045-4591-9c95-c8b019e28916",
+                  "name": "Output_E",
+                  "type_name": "nos.mediaio.RGBPixelFormat",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": "RGBA8",
+                  "def": "RGBA8",
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Output Format"
+                },
+                {
+                  "id": "fabe3427-4376-4108-b708-f121fb8b81a6",
+                  "name": "Input_F",
+                  "type_name": "nos.mediaio.GammaCurve",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": "REC709",
+                  "def": "REC709",
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Gamma Curve"
+                },
+                {
+                  "id": "e0217495-ea3e-46ff-8231-84d363645cdd",
+                  "name": "Output_F",
+                  "type_name": "nos.mediaio.GammaCurve",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": "REC709",
+                  "def": "REC709",
+                  "live": true,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Gamma Curve"
+                }
+              ],
+              "pos": {
+                "x": 247.0,
+                "y": 125.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "description": "Ring buffer with one or more independent input/output channel pairs sharing a single ring size. Right-click the node to add a channel, right-click an Input_X or Output_X pin to remove its channel.",
+              "display_name": "Multi Ring Buffer",
+              "plugin_version": {
+                "major": 3,
+                "minor": 15,
+                "patch": 0
+              }
+            },
+            {
+              "id": "8d8bf27a-47ef-47da-aba7-04045e3f2cf0",
+              "name": "Thread",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "f06eee73-7aca-473d-97ed-f315b5e6a7dc",
+                  "name": "Output",
+                  "type_name": "nos.exe",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "def": {},
+                  "contents_type": "JobPin",
+                  "contents": {}
+                },
+                {
+                  "id": "c0ba385a-37e4-4d41-adcf-924364510da3",
+                  "name": "Input",
+                  "type_name": "nos.exe",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {},
+                  "referred_by": [
+                    "9f66c060-2e6d-4f31-81a0-40ebc8517a9b"
+                  ],
+                  "def": {},
+                  "meta_data_map": [
+                    {
+                      "key": "PinHidden",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {}
+                }
+              ],
+              "pos": {
+                "x": -20.0,
+                "y": 2.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            },
+            {
+              "id": "8b1b8ee8-26b5-4a2f-a5ee-c9ff23f6289c",
+              "name": "Input_B",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "41e3113c-10a7-4b67-b475-078516167638",
+                  "name": "Output",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 15,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "ATC_LTC"
+                  },
+                  "min": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "max": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "def": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Timecode"
+                },
+                {
+                  "id": "590f5ef6-2483-48a8-9ec4-62cd117602e6",
+                  "name": "Input",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 15,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "ATC_LTC"
+                  },
+                  "referred_by": [
+                    "9a207f25-3715-4070-b16c-720210b447f8"
+                  ],
+                  "min": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "max": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "def": {
+                    "hours": 0,
+                    "minutes": 0,
+                    "seconds": 0,
+                    "frames": 0,
+                    "drop_frame": false,
+                    "source": "Auto"
+                  },
+                  "meta_data_map": [
+                    {
+                      "key": "PinHidden",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Timecode"
+                }
+              ],
+              "pos": {
+                "x": -27.0,
+                "y": 112.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "display_name": "Timecode",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            },
+            {
+              "id": "dd48d51e-f1fc-4a82-915e-3278eab44870",
+              "name": "Input_C",
+              "class_name": "nos.internal.GraphInput",
+              "pins": [
+                {
+                  "id": "fdcc2847-5013-4b9a-8c4c-e82dcd58ce6c",
+                  "name": "Output",
+                  "type_name": "bool",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": false,
+                  "def": false,
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Write"
+                },
+                {
+                  "id": "b08ebd74-85ba-47f0-afe1-714c890cba48",
+                  "name": "Input",
+                  "type_name": "bool",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_ONLY",
+                  "visualizer": {},
+                  "data": false,
+                  "referred_by": [
+                    "74be8797-c11f-4f52-99a0-dc171279562e"
+                  ],
+                  "def": false,
+                  "meta_data_map": [
+                    {
+                      "key": "PinHidden",
+                      "value": "true"
+                    }
+                  ],
+                  "contents_type": "JobPin",
+                  "contents": {},
+                  "display_name": "Write"
+                }
+              ],
+              "pos": {
+                "x": -21.0,
+                "y": 156.0
+              },
+              "contents_type": "Job",
+              "contents": {
+                "type": ""
+              },
+              "function_category": "Default Node",
+              "display_name": "Record",
+              "plugin_version": {
+                "major": 0,
+                "minor": 0,
+                "patch": 0
+              }
+            }
+          ],
+          "connections": [
+            {
+              "from": "e20d73a9-315d-40bf-9dd9-f5893155cd6d",
+              "to": "2e9a799b-d4e3-4273-9fe4-473274418b14",
+              "id": "1b5270fb-7b07-43af-9518-092f64fde091"
+            },
+            {
+              "from": "3a202e12-322d-4634-8f78-10be923ddcb4",
+              "to": "9fbc2858-ee68-4cd7-bb7a-b025151a6b7b",
+              "id": "7f08d571-0741-4f13-8ec2-7853887da72d"
+            },
+            {
+              "from": "0058db9b-5614-47b5-adb3-aff63eb72092",
+              "to": "52b68182-6518-439d-8a09-7da064cca63e",
+              "id": "e548180f-e15d-4236-a436-6021625a7f88"
+            },
+            {
+              "from": "cc8732f1-00c8-4cbd-b72d-00f7164d0f5b",
+              "to": "a69742c2-655f-4062-bd57-d648057cb508",
+              "id": "b0d05756-5202-4061-9bc6-488b0730b427"
+            },
+            {
+              "from": "e0217495-ea3e-46ff-8231-84d363645cdd",
+              "to": "2d2ff8a1-4e2d-474e-9c20-37c189e54604",
+              "id": "2068f7bd-60ae-4b5e-aa7b-f9550f90d422"
+            },
+            {
+              "from": "b9700c31-bded-4f6c-bf5e-158dc2ec60ea",
+              "to": "b09c8a4e-2162-4188-a66d-f6c231947a69",
+              "id": "0cb54a07-f283-40cd-9cb3-b8d8d37d987c"
+            },
+            {
+              "from": "d1936339-9722-4b17-b15a-905817e8bf1c",
+              "to": "8d765d04-9bbf-44a0-a3ac-c50f5566919e",
+              "id": "4cbffe47-a7dc-446f-b56b-0d525574ef9f"
+            },
+            {
+              "from": "e5965779-359a-447d-b478-567c2066a658",
+              "to": "874550cd-2d7b-4896-ada6-66efe6febc79",
+              "id": "f6393f5f-5996-4f95-92c6-d00eb8c6c2f2"
+            },
+            {
+              "from": "1d5886e8-4303-4a2b-9695-9cc030eda6cf",
+              "to": "9e129a4f-9429-48a9-bd3e-6effe8b17c07",
+              "id": "0d5e32cc-7f79-46d0-bae9-16b5ce72d2a4"
+            },
+            {
+              "from": "b4aef3b5-f045-4591-9c95-c8b019e28916",
+              "to": "484df806-e253-4997-ad3b-b580d13b44b7",
+              "id": "ae50bcb9-a914-49a7-b49e-698905a9525f"
+            },
+            {
+              "from": "878411e8-a605-458a-bd72-a8045c825a98",
+              "to": "1e011fb8-c8ce-410c-99d9-06d777a6a44f",
+              "id": "4e6080d1-8282-42f4-8d92-e77d95c640cd"
+            },
+            {
+              "from": "8e8ebb04-cccb-4d30-bbc7-15605e1c5041",
+              "to": "9d9530d2-f21a-4e57-906d-ddd49d3c5aa3",
+              "id": "23815251-e0ce-4a6b-bb68-9a56d87dbe72"
+            },
+            {
+              "from": "f1e95345-21af-43d7-8441-8f5781eeb6da",
+              "to": "22008ed1-f58a-42e4-becb-faa1eb17cdb4",
+              "id": "15827dff-01c7-49bc-b84c-ca7a66b6afb6"
+            },
+            {
+              "from": "f06eee73-7aca-473d-97ed-f315b5e6a7dc",
+              "to": "98add52e-2caa-4828-9d73-a130277e2e7c",
+              "id": "f46b855a-5495-40ad-83ce-3b2341b62a27"
+            },
+            {
+              "from": "41e3113c-10a7-4b67-b475-078516167638",
+              "to": "e7d940c2-7181-40d8-b1d5-144f0dfb5673",
+              "id": "fb9fb53a-cd4c-45d0-bacf-282e773e429c"
+            },
+            {
+              "from": "fdcc2847-5013-4b9a-8c4c-e82dcd58ce6c",
+              "to": "0a0058c3-b36e-4879-a181-7e2cf367584f",
+              "id": "c553098e-2d3c-4ff7-9184-0f09f91b6481"
+            },
+            {
+              "from": "603958c6-4e9d-4e5b-9c37-1da94cbd14da",
+              "to": "13f9d47a-1b19-49ee-bed2-4ea249e7cfd4",
+              "id": "a69fe644-8bad-43a0-bd7f-f90cfd00956b"
+            },
+            {
+              "from": "49db87e8-0bb5-4ea5-bffa-85767db7c5d3",
+              "to": "decf34ce-1888-48c0-874e-c63c2b897f61",
+              "id": "35f0f1c9-349f-4fd4-9385-198dae346c45"
+            },
+            {
+              "from": "e6b09200-ad71-464b-8eb0-6bb74702bca2",
+              "to": "a47e137e-01ed-425c-a413-6a4aee711bdb",
+              "id": "ca91c808-dd76-4878-90d7-d53e002bbf5c"
+            },
+            {
+              "from": "603958c6-4e9d-4e5b-9c37-1da94cbd14da",
+              "to": "fabe3427-4376-4108-b708-f121fb8b81a6",
+              "id": "2c76445a-b76c-421f-b7e3-ab48a3ae20e0"
+            },
+            {
+              "from": "49db87e8-0bb5-4ea5-bffa-85767db7c5d3",
+              "to": "5c475308-2e3e-4c6a-b4ff-e29dc32bd65f",
+              "id": "16d81afb-6491-4059-adb8-1c9ee647d7d9"
+            },
+            {
+              "from": "f1e95345-21af-43d7-8441-8f5781eeb6da",
+              "to": "d5c574a8-9d47-4b59-aa9f-75e4612b6eb5",
+              "id": "957765ca-f89f-4ef5-afd0-b7f6a93511b8"
+            }
+          ]
+        },
+        "meta_data_map": [
+          { "key": "NodeStatusPortal", "value": "/WriteDPX" }
+        ],
+        "function_category": "Default Node",
+        "plugin_version": {
+          "major": 0,
+          "minor": 0,
+          "patch": 0
+        }
+      }
+    }
+  ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/TimecodeFromFrameNumber.nosnode
+++ b/Nodes/TimecodeFromFrameNumber.nosnode
@@ -1,0 +1,66 @@
+{
+    "nodes": [
+        {
+            "class_name": "TimecodeFromFrameNumber",
+            "menu_info": {
+                "category": "Media IO|Timecode",
+                "display_name": "Timecode From Frame Number"
+            },
+            "node": {
+                "class_name": "TimecodeFromFrameNumber",
+                "display_name": "Timecode From Frame Number",
+                "contents_type": "Job",
+                "always_execute": true,
+                "description": "Converts a frame number (frames since 00:00:00:00) to a decoded SMPTE Timecode struct. Applies\nSMPTE drop-frame correction when DropFrame is true and the frame rate is 29.97 or 59.94. The\nresulting Timecode struct can be fed directly into AJA Out (Timecode pin) or InjectTimecode\n(to embed as an ATC packet in an ANCFrame).",
+              "pins": [
+                {
+                  "name": "FrameNumber",
+                  "display_name": "Frame Number",
+                  "description": "Total frames since 00:00:00:00. Converted to HH:MM:SS:FF using FrameRateOverride (or the\nauto-inferred rate) with SMPTE drop-frame correction applied when DropFrame is true.",
+                  "type_name": "uint",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": 0
+                },
+                {
+                  "name": "FrameRateOverride",
+                  "display_name": "Frame Rate Override",
+                  "description": "Optional override for the frame rate used when converting frame number to HH:MM:SS:FF. Leave\nat 0 to auto-infer from the executing path's fixed-step timing.",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": 0.0,
+                  "min": "0"
+                },
+                {
+                  "name": "DropFrame",
+                  "display_name": "Drop Frame",
+                  "description": "When true, SMPTE drop-frame math is applied to the frame-number-to-timecode conversion and\nthe drop-frame flag is propagated into the output Timecode. Drop-frame is only defined for\n29.97/59.94; consumers should ignore the flag at integer rates.",
+                  "type_name": "bool",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": false
+                },
+                {
+                  "name": "Source",
+                  "display_name": "Source",
+                  "description": "ATC carriage to encode in the output Timecode's source field (DBB1 bits 2-0 when serialized\nto ATC). Auto is treated as ATC_LTC.",
+                  "type_name": "nos.mediaio.ATCSource",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": 1
+                },
+                {
+                  "name": "Timecode",
+                  "display_name": "Timecode",
+                  "description": "Decoded SMPTE timecode (HH:MM:SS:FF + drop-frame flag + ATC source).",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY"
+                }
+              ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/TimecodePlayer.nosnode
+++ b/Nodes/TimecodePlayer.nosnode
@@ -1,0 +1,93 @@
+{
+    "nodes": [
+        {
+            "class_name": "TimecodePlayer",
+            "menu_info": {
+                "category": "Media IO|Timecode",
+                "display_name": "Timecode Player",
+                "name_aliases": [ "timecode", "play", "clock", "generator" ]
+            },
+            "node": {
+                "class_name": "TimecodePlayer",
+                "display_name": "Timecode Player",
+                "contents_type": "Job",
+                "description": "Plays a running SMPTE timecode, advancing one frame per run while playing. Rate is taken\nfrom the path's fixed-step timing. Ranged mode runs from Start Time to End Timecode then stops;\nContinuous counts up without bound.",
+                "pins": [
+                    {
+                        "name": "InExe",
+                        "type_name": "nos.exe",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY"
+                    },
+                    {
+                        "name": "OutExe",
+                        "type_name": "nos.exe",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY"
+                    },
+                    {
+                        "name": "StartTime",
+                        "display_name": "Start Time",
+                        "description": "Timecode the player starts from; its drop-frame flag and source carry into the output.",
+                        "type_name": "nos.mediaio.Timecode",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY"
+                    },
+                    {
+                        "name": "EndTimecode",
+                        "display_name": "End Timecode",
+                        "description": "Timecode the player stops at in Ranged mode. Passive in Continuous mode.",
+                        "type_name": "nos.mediaio.Timecode",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY"
+                    },
+                    {
+                        "name": "Mode",
+                        "description": "Ranged runs from Start Time to End Timecode then stops; Continuous counts up without bound.",
+                        "type_name": "nos.mediaio.TimecodePlayerMode",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "data": "Ranged"
+                    },
+                    {
+                        "name": "Timecode",
+                        "display_name": "Timecode",
+                        "description": "Current SMPTE timecode.",
+                        "type_name": "nos.mediaio.Timecode",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY"
+                    },
+                    {
+                        "name": "Playing",
+                        "description": "True while playing, false when stopped.",
+                        "type_name": "bool",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY",
+                        "data": false
+                    }
+                ],
+                "functions": [
+                    {
+                        "class_name": "Reset",
+                        "contents_type": "Job",
+                        "description": "Returns to Start Time.",
+                        "pins": []
+                    },
+                    {
+                        "class_name": "Start",
+                        "contents_type": "Job",
+                        "description": "Resumes playback.",
+                        "pins": []
+                    },
+                    {
+                        "class_name": "Stop",
+                        "contents_type": "Job",
+                        "description": "Pauses, holding the current timecode.",
+                        "pins": []
+                    }
+                ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/TimecodeToFrameNumber.nosnode
+++ b/Nodes/TimecodeToFrameNumber.nosnode
@@ -1,0 +1,46 @@
+{
+    "nodes": [
+        {
+            "class_name": "TimecodeToFrameNumber",
+            "menu_info": {
+                "category": "Media IO|Timecode",
+                "display_name": "Timecode To Frame Number"
+            },
+            "node": {
+                "class_name": "TimecodeToFrameNumber",
+                "display_name": "Timecode To Frame Number",
+                "contents_type": "Job",
+                "description": "Converts a decoded SMPTE Timecode struct to a frame number (frames since 00:00:00:00). SMPTE\ndrop-frame correction is applied when the Timecode's drop-frame flag is set and the frame rate\nis 29.97/59.94. For a human-readable HH:MM:SS:FF string use TimecodeToString.",
+              "pins": [
+                {
+                  "name": "Timecode",
+                  "display_name": "Timecode",
+                  "description": "Decoded SMPTE timecode to convert.",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY"
+                },
+                {
+                  "name": "FrameRateOverride",
+                  "display_name": "Frame Rate Override",
+                  "description": "Optional override for the frame rate used to convert HH:MM:SS:FF back to a frame number.\nLeave at 0 to auto-infer from the executing path's fixed-step timing.",
+                  "type_name": "float",
+                  "show_as": "PROPERTY",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                  "data": 0.0,
+                  "min": "0"
+                },
+                {
+                  "name": "FrameNumber",
+                  "display_name": "Frame Number",
+                  "description": "Total frames since 00:00:00:00. SMPTE drop-frame correction is applied when the input\nTimecode's drop-frame flag is set and the frame rate is 29.97/59.94.",
+                  "type_name": "uint",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY"
+                }
+              ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/TimecodeToString.nosnode
+++ b/Nodes/TimecodeToString.nosnode
@@ -1,0 +1,36 @@
+{
+    "nodes": [
+        {
+            "class_name": "TimecodeToString",
+            "menu_info": {
+                "category": "Media IO|Timecode",
+                "display_name": "Timecode To String"
+            },
+            "node": {
+                "class_name": "TimecodeToString",
+                "display_name": "Timecode To String",
+                "contents_type": "Job",
+                "description": "Formats a decoded SMPTE Timecode struct as HH:MM:SS:FF (':' separator), or HH:MM:SS;FF when\nthe drop-frame flag is set.",
+              "pins": [
+                {
+                  "name": "Timecode",
+                  "display_name": "Timecode",
+                  "description": "Decoded SMPTE timecode to format.",
+                  "type_name": "nos.mediaio.Timecode",
+                  "show_as": "INPUT_PIN",
+                  "can_show_as": "INPUT_PIN_OR_PROPERTY"
+                },
+                {
+                  "name": "TimecodeStr",
+                  "display_name": "Timecode String",
+                  "description": "HH:MM:SS:FF (':' separator), or HH:MM:SS;FF when the input Timecode's drop-frame flag is set.",
+                  "type_name": "string",
+                  "show_as": "OUTPUT_PIN",
+                  "can_show_as": "OUTPUT_PIN_ONLY"
+                }
+              ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Nodes/WriteDPX.nosnode
+++ b/Nodes/WriteDPX.nosnode
@@ -1,0 +1,97 @@
+{
+    "nodes": [
+        {
+            "class_name": "WriteDPX",
+            "menu_info": {
+                "category": "Media IO|Recording",
+                "display_name": "Write DPX",
+                "name_aliases": [ "record clip", "record buffer", "buffer recorder", "capture clip", "dpx writer", "dpx sequence" ]
+            },
+            "node": {
+                "class_name": "WriteDPX",
+                "display_name": "Write DPX",
+                "contents_type": "Job",
+                "description": "Writes the input Buffer to disk as an uncompressed DPX sequence while Write is true.\nEach execution writes a 'HH-MM-SS-FF.dpx' file - named from and with the SMPTE timecode\nembedded in its header - under Path. The pixels are produced upstream by a Texture To\nBuffer node (encoding + packing) and made host-visible by a download ring, so this node\ndoes no GPU work: it maps the buffer and writes the bytes. Resolution, Output Format and\nTransfer describe the buffer for the DPX header and must match the Texture To Buffer node.\nDrive it through the In/Out exe pins to schedule it. Play the result back with the\nPlayback Clip node.",
+                "pins": [
+                    {
+                        "name": "InExe",
+                        "type_name": "nos.exe",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY"
+                    },
+                    {
+                        "name": "OutExe",
+                        "type_name": "nos.exe",
+                        "show_as": "OUTPUT_PIN",
+                        "can_show_as": "OUTPUT_PIN_ONLY"
+                    },
+                    {
+                        "name": "Buffer",
+                        "display_name": "Buffer",
+                        "description": "Host-visible buffer of packed pixels to record, from a Texture To Buffer node via a\ndownload ring. Written to disk verbatim after the DPX header.",
+                        "type_name": "nos.sys.vulkan.Buffer",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_ONLY"
+                    },
+                    {
+                        "name": "Timecode",
+                        "display_name": "Timecode",
+                        "description": "SMPTE timecode for the current frame. Names the file 'HH-MM-SS-FF.dpx' and is\nembedded in the DPX header.",
+                        "type_name": "nos.mediaio.Timecode",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY"
+                    },
+                    {
+                        "name": "Path",
+                        "display_name": "Path",
+                        "description": "Output directory for the recorded .dpx sequence. Created if it does not exist.",
+                        "type_name": "string",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "visualizer": { "type": "FOLDER_PICKER" }
+                    },
+                    {
+                        "name": "Write",
+                        "display_name": "Write",
+                        "description": "While true, every executed frame is written to disk. While false, nothing is written.",
+                        "type_name": "bool",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "data": false
+                    },
+                    {
+                        "name": "Resolution",
+                        "display_name": "Resolution",
+                        "description": "Frame size of the buffer in pixels. Must match the texture the Texture To Buffer\nnode packed; drives the DPX header and how many bytes are written.",
+                        "type_name": "nos.fb.vec2u",
+                        "show_as": "INPUT_PIN",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "data": {
+                            "x": 1920,
+                            "y": 1080
+                        }
+                    },
+                    {
+                        "name": "OutputFormat",
+                        "display_name": "Output Format",
+                        "description": "Packed pixel layout of the buffer. Must match the Texture To Buffer node's Output\nFormat: RGBA8 / RGBA16 / RGB10 (DPX Method A) / RGB8.",
+                        "type_name": "nos.mediaio.RGBPixelFormat",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "data": "RGBA8"
+                    },
+                    {
+                        "name": "Transfer",
+                        "display_name": "Transfer",
+                        "description": "Transfer curve the buffer was encoded with upstream, recorded in the DPX header's\ntransfer characteristic. IDENTITY -> linear, REC709 -> CCIR 709; other curves are\ntagged user-defined.",
+                        "type_name": "nos.mediaio.GammaCurve",
+                        "show_as": "PROPERTY",
+                        "can_show_as": "INPUT_PIN_OR_PROPERTY",
+                        "data": "SRGB"
+                    }
+                ]
+            }
+        }
+    ],
+    "schema_version": "1.4-v1"
+}

--- a/Shaders/ConversionsCommon.glsl
+++ b/Shaders/ConversionsCommon.glsl
@@ -2,6 +2,7 @@
 
 #extension GL_EXT_shader_16bit_storage : enable
 
+#include "GammaFunctions.glsl"
 struct umat4
 {
     uvec4 x, y, z, w;
@@ -19,6 +20,8 @@ layout(binding = 2) uniform UBO
     bool IsOutputInterlaced;
     // YCBCR2RGB
     uint IsInterlaced;
+    uint GammaCurve;
+    bool UseLUT;
 } ubo;
 
 // Defined in Conversion.fbs
@@ -39,65 +42,21 @@ layout(binding = 3) readonly buffer SSBO
 #define N10 ((1<<10)-1)
 #define N8  ((1<< 8)-1)
 
-
-vec4 LinearToRec709(in vec4 c)
-{
-    c = clamp(c, vec4(0), vec4(1));
-    return mix(pow(c, vec4(0.45)) * 1.099 - 0.099, c * 4.5, lessThan(c, vec4(0.018)));
-}
-
-vec4 Rec709ToLinear(in vec4 c)
-{
-    return mix(pow((c + 0.099) / 1.099, vec4(1.0/0.45)), c / 4.5, lessThan(c, vec4(0.081)));
-}
-
-vec4 HLGToLinear(in vec4 c) 
-{
-	c = max(c, vec4(0.0));
-    const vec4 c0 = c * c / 3.0;
-    const vec4 c1 = exp(c / 0.17883277 - 5.61582460179) + 0.02372241;
-    return mix(c1, c0, lessThan(c, vec4(0.5)));
-}
-
-vec4 LinearToHLG(in vec4 c) 
-{
-    const vec4 c0 = sqrt(3 * c);
-    const vec4 c1 = log(c - 0.02372241) * 0.17883277 + 1.00429346;
-    return mix(c1, c0, lessThan(c, vec4(1.0/12.0)));
-}
-
-const vec4 m1 = vec4(0.1593017578125); // = 2610. / 4096. * .25;
-const vec4 m2 = vec4(78.84375); // = 2523. / 4096. *  128;
-const vec4 c1 = vec4(0.8359375); // = 2392. / 4096. * 32 - 2413./4096.*32 + 1;
-const vec4 c2 = vec4(18.8515625); // = 2413. / 4096. * 32;
-const vec4 c3 = vec4(18.6875); // = 2392. / 4096. * 32;
-
-vec4 ST2084ToLinear(vec4 c)
-{
-    c = pow(c, 1. / m2);
-    return pow(max(c - c1, vec4(0)) / (c2  - c3 * c), 1. / m1);
-}
-
-vec4 LinearToST2084(vec4 c)
-{
-    c = pow(c, m1);
-    return pow((c1 + c2 * c) / (1 + c3 * c), m2);
-}
-
-uvec4 IDX4(uvec4 i)
-{
-    return uvec4(GammaLUT.LUT[i.x], GammaLUT.LUT[i.y], GammaLUT.LUT[i.z], GammaLUT.LUT[i.w]);
-}
-
 uvec3 IDX(uvec3 i)
 {
     return uvec3(GammaLUT.LUT[i.x], GammaLUT.LUT[i.y], GammaLUT.LUT[i.z]);
 }
 
-uvec3 IDXuu(uvec3 c) { return IDX(min(c, N10)); }
-uvec3 IDXfu( vec3 c) { return IDXuu(uvec3(round(c * N10))); }
- vec3 IDXuf(uvec3 c) { return IDXuu(c) / float(N16); }
- vec3 IDXff( vec3 c) { return IDXfu(c) / float(N16); }
+uvec3 IDXuu(uvec3 c) { return IDX(clamp(c, 0, N10)); }
+
+vec3 IDXff( vec3 c)
+{
+    c *= N10;
+    vec3 f = fract(c);
+    vec3 s0 = IDXuu(uvec3(c));
+    vec3 s1 = IDXuu(uvec3(c)+1);
+    return mix(s0, s1, f) / float(N16);
+}
 
 /*
 In:
@@ -107,22 +66,16 @@ Out:
 */
 
 
-vec4  SDR_In (in vec3 c) 
-{ 
-    return  vec4(IDXff((ubo.Colorspace * vec4(c, 1)).xyz), 1); 
+vec4  SDR_In (in vec3 c)
+{
+    return  vec4(IDXff((ubo.Colorspace * vec4(c, 1)).xyz), 1);
 }
 
-vec4  SDR_In_N (in uvec3 c, float N) 
-{ 
-    return  vec4(IDXff((ubo.Colorspace * vec4(c / N, 1)).xyz), 1); 
+uvec3 SDR_Out_N(in vec3 c, float N)
+{
+    c = ubo.UseLUT ? IDXff(c) : FromLinear(c, ubo.GammaCurve);
+    return uvec3(round(clamp(ubo.Colorspace * vec4(c, 1), 0.0, 1.0).xyz * N));
 }
 
-uvec3 SDR_Out_N(in vec3 c, float N)  
-{ 
-    return uvec3(round(clamp(ubo.Colorspace * vec4(IDXff(c), 1), 0.0, 1.0).xyz * N)); 
-}
-
-vec4  SDR_In_10 (in uvec3 c) { return SDR_In_N (c, N10); }
-vec4  SDR_In_8  (in uvec3 c) { return SDR_In_N (c, N8); }
 uvec3 SDR_Out_10(in vec3 c)  { return SDR_Out_N(c, N10); }
 uvec3 SDR_Out_8 (in vec3 c)  { return SDR_Out_N(c, N8); }

--- a/Shaders/ConversionsCommon.glsl
+++ b/Shaders/ConversionsCommon.glsl
@@ -68,7 +68,9 @@ Out:
 
 vec4  SDR_In (in vec3 c)
 {
-    return  vec4(IDXff((ubo.Colorspace * vec4(c, 1)).xyz), 1);
+    vec3 v = (ubo.Colorspace * vec4(c, 1)).xyz;
+    v = ubo.UseLUT ? IDXff(v) : ToLinear(v, ubo.GammaCurve);
+    return  vec4(v, 1);
 }
 
 uvec3 SDR_Out_N(in vec3 c, float N)

--- a/Shaders/GammaFunctions.glsl
+++ b/Shaders/GammaFunctions.glsl
@@ -1,0 +1,68 @@
+// must match Conversion.fbs
+#define GAMMA_CURVE_REC709  0
+#define GAMMA_CURVE_HLG  1
+#define GAMMA_CURVE_ST2084 2
+#define GAMMA_CURVE_SRGB 3
+#define GAMMA_CURVE_IDENTITY 4
+
+vec3 Rec709ToLinear(vec3 c)
+{
+    return mix(c / 4.5, pow((c + 0.099) / 1.099, vec3(1.0 / 0.45)), lessThanEqual(vec3(0.081), c));
+}
+vec3 LinearToRec709(vec3 c)
+{
+    return mix(c * 4.5, pow(c, vec3(0.45)) * 1.099 - 0.099, lessThanEqual(vec3(0.018), c));
+}
+vec3 HLGToLinear(vec3 c)
+{
+    return mix(c * c / 3.0, exp(c / 0.17883277 - 5.61582460179) + 0.02372241, lessThanEqual(vec3(0.5), c));
+}
+vec3 LinearToHLG(vec3 c)
+{
+    return mix(sqrt(c * 3.0), log(c - 0.02372241) * 0.17883277 + 1.00429346, lessThanEqual(vec3(1.0 / 12.0), c));
+}
+
+vec3 ST2084ToLinear(vec3 c)
+{
+    vec3 p = pow(c, vec3(0.01268331));
+    return pow(max(p - 0.8359375, 0.0) / (18.8515625 - 18.6875 * p), vec3(6.27739463));
+}
+
+vec3 LinearToST2084(vec3 c)
+{
+    vec3 p = pow(c, vec3(0.15930175));
+    return pow((0.8359375 + 18.8515625 * p) / (1.0 + 18.6875 * p), vec3(78.84375));
+}
+
+vec3 SRGBToLinear(vec3 c)
+{
+    return mix(c / 12.92, pow((c + 0.055) / 1.055, vec3(2.4)), lessThanEqual(vec3(0.04045), c));
+}
+vec3 LinearToSRGB(vec3 c)
+{
+    return mix(c * 12.92, pow(c, vec3(1.0 / 2.4)) * 1.055 - 0.055, lessThanEqual(vec3(0.0031308), c));
+}
+vec3 IdentityGamma(vec3 c)
+{
+    return c;
+}
+
+vec3 ToLinear(vec3 c, uint curve) {
+    switch (curve) {
+        case GAMMA_CURVE_REC709: return Rec709ToLinear(c);
+        case GAMMA_CURVE_HLG: return HLGToLinear(c);
+        case GAMMA_CURVE_ST2084: return ST2084ToLinear(c);
+        case GAMMA_CURVE_SRGB: return SRGBToLinear(c);
+        default: return c;
+    }
+}
+
+vec3 FromLinear(vec3 c, uint curve) {
+    switch (curve) {
+        case GAMMA_CURVE_REC709: return LinearToRec709(c);
+        case GAMMA_CURVE_HLG: return LinearToHLG(c);
+        case GAMMA_CURVE_ST2084: return LinearToST2084(c);
+        case GAMMA_CURVE_SRGB: return LinearToSRGB(c);
+        default: return c;
+    }
+}

--- a/Shaders/GammaFunctions.glsl
+++ b/Shaders/GammaFunctions.glsl
@@ -4,6 +4,7 @@
 #define GAMMA_CURVE_ST2084 2
 #define GAMMA_CURVE_SRGB 3
 #define GAMMA_CURVE_IDENTITY 4
+#define GAMMA_CURVE_SLOG3 5
 
 vec3 Rec709ToLinear(vec3 c)
 {
@@ -47,12 +48,28 @@ vec3 IdentityGamma(vec3 c)
     return c;
 }
 
+// Sony S-Log3 (full-range, normalized 0..1 code value).
+// Linear breakpoint 0.01125 → code 171.2102946929/1023 ≈ 0.16739.
+vec3 SLog3ToLinear(vec3 c)
+{
+    vec3 logBranch = pow(vec3(10.0), (c * 1023.0 - 420.0) / 261.5) * 0.19 - 0.01;
+    vec3 linBranch = (c * 1023.0 - 95.0) * (0.01125 / (171.2102946929 - 95.0));
+    return mix(linBranch, logBranch, lessThanEqual(vec3(171.2102946929 / 1023.0), c));
+}
+vec3 LinearToSLog3(vec3 c)
+{
+    vec3 logBranch = (420.0 + log((c + 0.01) / 0.19) * (261.5 / log(10.0))) / 1023.0;
+    vec3 linBranch = (c * ((171.2102946929 - 95.0) / 0.01125) + 95.0) / 1023.0;
+    return mix(linBranch, logBranch, lessThanEqual(vec3(0.01125), c));
+}
+
 vec3 ToLinear(vec3 c, uint curve) {
     switch (curve) {
         case GAMMA_CURVE_REC709: return Rec709ToLinear(c);
         case GAMMA_CURVE_HLG: return HLGToLinear(c);
         case GAMMA_CURVE_ST2084: return ST2084ToLinear(c);
         case GAMMA_CURVE_SRGB: return SRGBToLinear(c);
+        case GAMMA_CURVE_SLOG3: return SLog3ToLinear(c);
         default: return c;
     }
 }
@@ -63,6 +80,7 @@ vec3 FromLinear(vec3 c, uint curve) {
         case GAMMA_CURVE_HLG: return LinearToHLG(c);
         case GAMMA_CURVE_ST2084: return LinearToST2084(c);
         case GAMMA_CURVE_SRGB: return LinearToSRGB(c);
+        case GAMMA_CURVE_SLOG3: return LinearToSLog3(c);
         default: return c;
     }
 }

--- a/Shaders/LinearToSLog3.comp
+++ b/Shaders/LinearToSLog3.comp
@@ -1,0 +1,18 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#version 450
+#include "GammaFunctions.glsl"
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+layout (binding = 0) uniform sampler2D Source;
+layout (binding = 1, rgba16f) uniform writeonly image2D Output;
+
+void main()
+{
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = textureSize(Source, 0);
+    if (coord.x >= size.x || coord.y >= size.y) return;
+    vec4 c = texelFetch(Source, coord, 0);
+    imageStore(Output, coord, vec4(LinearToSLog3(c.rgb), c.a));
+}

--- a/Shaders/SLog3ToLinear.comp
+++ b/Shaders/SLog3ToLinear.comp
@@ -1,0 +1,18 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#version 450
+#include "GammaFunctions.glsl"
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+layout (binding = 0) uniform sampler2D Source;
+layout (binding = 1, rgba16f) uniform writeonly image2D Output;
+
+void main()
+{
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    ivec2 size = textureSize(Source, 0);
+    if (coord.x >= size.x || coord.y >= size.y) return;
+    vec4 c = texelFetch(Source, coord, 0);
+    imageStore(Output, coord, vec4(SLog3ToLinear(c.rgb), c.a));
+}

--- a/Shaders/TextureToBuffer.comp
+++ b/Shaders/TextureToBuffer.comp
@@ -1,0 +1,108 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+// Encodes the input RGB texture with a transfer curve (gamma LUT or analytic) and packs it
+// into the output buffer in one of the RGBPixelFormat layouts. No colorspace matrix and no
+// interlacing - a focused texture->buffer pack for the Record Clip path. The output buffer is
+// host-visible so it can be read back (via a download ring) and written to disk verbatim.
+
+#version 450
+
+#include "GammaFunctions.glsl"
+
+// Must match nos.mediaio.RGBPixelFormat in Conversion.fbs.
+#define PIXEL_FORMAT_RGBA8  0
+#define PIXEL_FORMAT_RGBA16 1
+#define PIXEL_FORMAT_RGB10  2
+#define PIXEL_FORMAT_RGB8   3
+
+layout (local_size_x = 16, local_size_y = 16) in;
+
+layout (binding = 0) uniform sampler2D Source;
+layout (binding = 1) writeonly buffer OutputBuffer
+{
+    uint Pixels[];
+} Output;
+layout (binding = 2) uniform UBO
+{
+    uint GammaCurve;
+    uint OutputFormat;
+} ubo;
+
+#define N16 ((1 << 16) - 1)
+#define N10 ((1 << 10) - 1)
+
+// Linear RGB -> encoded RGB in [0,1] via the analytic transfer curve.
+vec3 EncodeGamma(vec3 c)
+{
+    c = clamp(c, 0.0, 1.0);
+    return clamp(FromLinear(c, ubo.GammaCurve), 0.0, 1.0);
+}
+
+// 3 channels, 8-bit, tightly packed: 4 pixels (12 bytes) per invocation so each owns whole
+// 32-bit words and adjacent invocations never race on a shared word.
+void packRGB8(ivec2 size)
+{
+    ivec2 coord = ivec2(gl_GlobalInvocationID.x * 4, gl_GlobalInvocationID.y);
+    if (coord.x >= size.x || coord.y >= size.y)
+        return;
+
+    uvec3 px[4];
+    for (uint i = 0; i < 4; ++i)
+    {
+        uint xc = uint(coord.x) + i;
+        px[i] = (xc < uint(size.x))
+            ? uvec3(round(EncodeGamma(texelFetch(Source, ivec2(xc, coord.y), 0).rgb) * 255.0))
+            : uvec3(0);
+    }
+
+    uint word = (uint(coord.y) * uint(size.x) + uint(coord.x)) * 3 / 4; // byte offset / 4
+    uint vals[3] = uint[3](0u, 0u, 0u);
+    for (uint b = 0; b < 12; ++b)
+    {
+        uint comp = px[b / 3][b % 3] & 0xFFu;
+        vals[b / 4] |= comp << (24 - ((3 - (b % 4)) * 8));
+    }
+    Output.Pixels[word]     = vals[0];
+    Output.Pixels[word + 1] = vals[1];
+    Output.Pixels[word + 2] = vals[2];
+}
+
+void main()
+{
+    ivec2 size = textureSize(Source, 0);
+
+    if (ubo.OutputFormat == PIXEL_FORMAT_RGB8)
+    {
+        packRGB8(size);
+        return;
+    }
+
+    // Word-aligned formats: one pixel per invocation, each owns its own word(s).
+    ivec2 coord = ivec2(gl_GlobalInvocationID.xy);
+    if (coord.x >= size.x || coord.y >= size.y)
+        return;
+
+    vec4 texel = texelFetch(Source, coord, 0);
+    vec3 e = EncodeGamma(texel.rgb);
+    float a = clamp(texel.a, 0.0, 1.0);
+    uint idx = uint(coord.y) * uint(size.x) + uint(coord.x);
+
+    if (ubo.OutputFormat == PIXEL_FORMAT_RGBA8)
+    {
+        uvec3 c = uvec3(round(e * 255.0));
+        uint av = uint(round(a * 255.0));
+        Output.Pixels[idx] = (av << 24) | (c.b << 16) | (c.g << 8) | c.r;
+    }
+    else if (ubo.OutputFormat == PIXEL_FORMAT_RGBA16)
+    {
+        uvec3 c = uvec3(round(e * float(N16)));
+        uint av = uint(round(a * float(N16)));
+        Output.Pixels[idx * 2]     = (c.g << 16) | c.r;
+        Output.Pixels[idx * 2 + 1] = (av << 16) | c.b;
+    }
+    else // PIXEL_FORMAT_RGB10, DPX Method A: R[31:22] G[21:12] B[11:2], 2 LSB pad
+    {
+        uvec3 c = uvec3(round(e * float(N10)));
+        Output.Pixels[idx] = (c.r << 22) | (c.g << 12) | (c.b << 2);
+    }
+}

--- a/Source/Conversions.cpp
+++ b/Source/Conversions.cpp
@@ -308,6 +308,20 @@ struct GammaLUTNodeContext : NodeContext
 			return [](double c) {
 				return c;
 			};
+		case GammaCurve::SLOG3:
+			// Sony S-Log3 (full-range, normalized 0..1 code value).
+			// Linear breakpoint 0.01125 → code 171.2102946929/1023 ≈ 0.16739.
+			return toLinear
+				? [](double c) -> double {
+					return (c >= 171.2102946929 / 1023.0)
+						? (pow(10.0, (c * 1023.0 - 420.0) / 261.5) * 0.19 - 0.01)
+						: ((c * 1023.0 - 95.0) * 0.01125 / (171.2102946929 - 95.0));
+				}
+				: [](double c) -> double {
+					return (c >= 0.01125)
+						? ((420.0 + log10((c + 0.01) / 0.19) * 261.5) / 1023.0)
+						: ((c * (171.2102946929 - 95.0) / 0.01125 + 95.0) / 1023.0);
+				};
 		}
 	}
 
@@ -317,7 +331,8 @@ struct GammaLUTNodeContext : NodeContext
 		auto fn = GetLUTFunction(toLinear, curve);
 		for (uint32_t i = 0; i < 1 << bits; ++i)
 		{
-			re[i] = uint16_t(double((1 << 16) - 1) * fn(double(i) / double((1 << bits) - 1)) + 0.5);
+			double v = glm::clamp(fn(double(i) / double((1 << bits) - 1)), 0.0, 1.0);
+			re[i] = uint16_t(double((1 << 16) - 1) * v + 0.5);
 		}
 		return re;
 	}
@@ -340,6 +355,11 @@ struct ColorSpaceMatrixNodeContext : NodeContext
 		{
 		case ColorSpace::REC601: return {.299, .114};
 		case ColorSpace::REC2020: return {.2627, .0593};
+		// Sony S-Gamut3 / S-Gamut3.Cine luma (R, B) coefficients, derived from the
+		// published primaries against D65 white. Blue is negative because the blue
+		// primary lies outside the spectral locus.
+		case ColorSpace::SGAMUT3: return {0.2709805, -0.0575869};
+		case ColorSpace::SGAMUT3CINE: return {0.2150825, -0.1001485};
 		case ColorSpace::REC709:
 		default: return {.2126, .0722};
 		}
@@ -395,6 +415,60 @@ struct ColorSpaceMatrixNodeContext : NodeContext
 nosResult RegisterColorSpaceMatrix(nosNodeFunctions* funcs)
 {
 	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("nos.mediaio.ColorSpaceMatrix"), ColorSpaceMatrixNodeContext, funcs);
+	return NOS_RESULT_SUCCESS;
+}
+
+// Applies an S-Log3 transfer (encode or decode, picked by the bound shader) to the input
+// texture and writes a half-float result. The encode/decode pair share this context; only
+// the registered shader differs.
+struct SLog3GammaPassNodeContext : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		auto inputTex = params.GetPinObject<sys::vulkan::Texture>(NOS_NAME_STATIC("Source"));
+		auto inputTexInfo = sys::vulkan::GetResourceInfo(inputTex);
+		if (!inputTexInfo || !inputTex.IsValid())
+		{
+			nosEngine.LogE("SLog3 Node: Input texture is not valid!");
+			return NOS_RESULT_FAILED;
+		}
+		auto outputTex = params.GetPinObject<sys::vulkan::Texture>(NOS_NAME_STATIC("Output"));
+		auto outputTexInfo = sys::vulkan::GetResourceInfo(outputTex);
+
+		constexpr auto reqFormat = NOS_FORMAT_R16G16B16A16_SFLOAT;
+		const uint32_t w = inputTexInfo->Width;
+		const uint32_t h = inputTexInfo->Height;
+		nosTextureFieldType inputFieldType = sys::vulkan::GetResourceFieldType(inputTex);
+		if (!outputTexInfo || outputTexInfo->Width != w || outputTexInfo->Height != h ||
+			outputTexInfo->Format != reqFormat)
+		{
+			auto texObj = sys::vulkan::CreateTexture(
+				{
+					.Width = w,
+					.Height = h,
+					.Format = reqFormat,
+				},
+				"SLog3Result");
+			SetPinObject(NOS_NAME_STATIC("Output"), texObj);
+			nosVulkan->SetResourceFieldType(texObj, inputFieldType);
+		}
+		SetPinValue(NOS_NAME_STATIC("DispatchSize"),
+			nosVec2u(uint32_t(glm::ceil(w / 16.0f)), uint32_t(glm::ceil(h / 16.0f))));
+		return nosVulkan->ExecuteGPUNode(this, params.RawParams);
+	}
+};
+
+nosResult RegisterSLog3ToLinear(nosNodeFunctions* funcs)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("nos.mediaio.SLog3ToLinear"), SLog3GammaPassNodeContext, funcs);
+	return NOS_RESULT_SUCCESS;
+}
+
+nosResult RegisterLinearToSLog3(nosNodeFunctions* funcs)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("nos.mediaio.LinearToSLog3"), SLog3GammaPassNodeContext, funcs);
 	return NOS_RESULT_SUCCESS;
 }
 
@@ -481,6 +555,78 @@ struct NV12ToRGBANodeContext : NodeContext
 nosResult RegisterNV12ToRGBA(nosNodeFunctions* funcs)
 {
 	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("nos.mediaio.NV12ToRGBA"), NV12ToRGBANodeContext, funcs);
+	return NOS_RESULT_SUCCESS;
+}
+
+// Byte size of the packed output buffer for one frame in the given format. RGB8 is rounded
+// up to a whole 32-bit word because the shader writes it a word at a time.
+static uint32_t GetTextureBufferSize(RGBPixelFormat fmt, uint32_t width, uint32_t height)
+{
+	uint64_t pixels = uint64_t(width) * height;
+	switch (fmt)
+	{
+	case RGBPixelFormat::RGBA16: return uint32_t(pixels * 8);
+	case RGBPixelFormat::RGB8:   return uint32_t(((pixels * 3) + 3) & ~uint64_t(3));
+	case RGBPixelFormat::RGBA8:
+	case RGBPixelFormat::RGB10:
+	default:                       return uint32_t(pixels * 4);
+	}
+}
+
+// Workgroup count for the 16x16 shader. RGB8 packs 4 pixels per invocation in X.
+static nosVec2u GetTextureBufferDispatch(RGBPixelFormat fmt, uint32_t width, uint32_t height)
+{
+	uint32_t threadsX = (fmt == RGBPixelFormat::RGB8) ? (width + 3) / 4 : width;
+	return nosVec2u((threadsX + 15) / 16, (height + 15) / 16);
+}
+
+// Encodes the input texture with a gamma curve (LUT or analytic) and packs it into a
+// host-visible buffer in the chosen RGB* layout, so a download ring + Record Clip can read
+// it back and write it to disk. Like RGB2YCbCr but RGB-only: no colorspace matrix, no
+// interlacing. The output buffer is HOST_VISIBLE | DOWNLOAD; the compute shader writes it
+// directly.
+struct TextureToBufferNodeContext : NodeContext
+{
+	using NodeContext::NodeContext;
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		auto fmt = *params.GetPinValue<RGBPixelFormat>(NOS_NAME_STATIC("OutputFormat"));
+		auto inputTex = params.GetPinObject<sys::vulkan::Texture>(NOS_NAME_STATIC("Source"));
+		auto inputTexInfo = sys::vulkan::GetResourceInfo(inputTex);
+		if (!inputTexInfo || !inputTex.IsValid())
+		{
+			nosEngine.LogE("TextureToBuffer Node: Input texture is not valid!");
+			return NOS_RESULT_FAILED;
+		}
+		auto outputBuf = params.GetPinObject<sys::vulkan::Buffer>(NOS_NAME_STATIC("Output"));
+		auto outputBufInfo = sys::vulkan::GetResourceInfo(outputBuf);
+
+		uint32_t width = inputTexInfo->Width, height = inputTexInfo->Height;
+		uint32_t bufSize = GetTextureBufferSize(fmt, width, height);
+		constexpr auto outMemoryFlags = nosMemoryFlags(NOS_MEMORY_FLAGS_HOST_VISIBLE | NOS_MEMORY_FLAGS_DOWNLOAD);
+		if (!outputBufInfo || outputBufInfo->Size != bufSize || outputBufInfo->MemoryFlags != outMemoryFlags)
+		{
+			auto bufObj = sys::vulkan::CreateBuffer(
+				nosBufferInfo{
+					.Size = bufSize,
+					.Usage = nosBufferUsage(NOS_BUFFER_USAGE_TRANSFER_SRC | NOS_BUFFER_USAGE_STORAGE_BUFFER),
+					.MemoryFlags = outMemoryFlags,
+				},
+				"TextureToBufferResult");
+			SetPinObject(NOS_NAME_STATIC("Output"), bufObj);
+			nosVulkan->SetResourceFieldType(bufObj, NOS_TEXTURE_FIELD_TYPE_PROGRESSIVE);
+		}
+		else
+			nosVulkan->SetResourceFieldType(outputBuf, NOS_TEXTURE_FIELD_TYPE_PROGRESSIVE);
+		SetPinValue(NOS_NAME_STATIC("DispatchSize"), GetTextureBufferDispatch(fmt, width, height));
+		return nosVulkan->ExecuteGPUNode(this, params.RawParams);
+	}
+};
+
+nosResult RegisterTextureToBuffer(nosNodeFunctions* funcs)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("nos.mediaio.TextureToBuffer"), TextureToBufferNodeContext, funcs);
 	return NOS_RESULT_SUCCESS;
 }
 

--- a/Source/Dpx.h
+++ b/Source/Dpx.h
@@ -1,0 +1,191 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#pragma once
+
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#include "nosMediaio/ANC_generated.h"
+
+// Minimal DPX (SMPTE ST 268M) reader/writer for uncompressed RGB/RGBA frames.
+// Files are written little-endian so header fields and pixel data go to disk with no
+// byte-swapping, and the pixel data is the texture readback buffer verbatim.
+// Header field offsets follow the DPX V2.0 spec (SMPTE ST 268M); see the field/offset table in
+// FADGI "Guidelines for Embedded Metadata within DPX Files":
+// https://www.digitizationguidelines.gov/audio-visual/documents/DPX_Embed_Guideline_20180507.pdf
+namespace nos::mediaio::dpx
+{
+
+// The DPX header is a fixed 2048 bytes; image data follows immediately after.
+constexpr uint32_t HEADER_SIZE = 2048;
+
+// DPX "Transfer Characteristic" / "Colorimetric Specification" codes (SMPTE ST 268M). Both
+// header fields share this one enumeration. Values 2, 3, 11, 12 describe amplitude transfer
+// functions only and are NOT valid colorimetric specifications - the colorimetric field takes
+// user-defined (0), printing density (1), unspecified video (4), or a standard primaries code
+// (5..10). Codes match OpenImageIO's libdpx (DPXHeader.h "Characteristic").
+constexpr uint8_t CHARACTERISTIC_USER_DEFINED      = 0;
+constexpr uint8_t CHARACTERISTIC_PRINTING_DENSITY  = 1;
+constexpr uint8_t CHARACTERISTIC_LINEAR            = 2;    // transfer only
+constexpr uint8_t CHARACTERISTIC_LOGARITHMIC       = 3;    // transfer only
+constexpr uint8_t CHARACTERISTIC_UNSPECIFIED_VIDEO = 4;
+constexpr uint8_t CHARACTERISTIC_SMPTE274M         = 5;
+constexpr uint8_t CHARACTERISTIC_ITUR709           = 6;    // Rec.709 (CCIR 709-1)
+constexpr uint8_t CHARACTERISTIC_ITUR601_625       = 7;    // Rec.601 system B/G
+constexpr uint8_t CHARACTERISTIC_ITUR601_525       = 8;    // Rec.601 system M
+constexpr uint8_t CHARACTERISTIC_NTSC              = 9;
+constexpr uint8_t CHARACTERISTIC_PAL               = 10;
+constexpr uint8_t CHARACTERISTIC_UNDEFINED         = 0xFF; // field not specified
+
+// Aliases for the transfer field, kept for existing call sites.
+constexpr uint8_t TRANSFER_USER_DEFINED = CHARACTERISTIC_USER_DEFINED; // e.g. sRGB-encoded pixels
+constexpr uint8_t TRANSFER_LINEAR       = CHARACTERISTIC_LINEAR;
+
+// Frame-rate field offsets. DPX has two standard R32 (float) frame-rate fields and no integer
+// rational: the motion-picture film header's (the canonical rate most DPX tools read) and the
+// television header's (companion to the timecode, which also lives in the TV header). Fractional
+// rates (59.94, 29.97) round to the nearest float, so playback compares them with a small tolerance.
+constexpr uint32_t FILM_FRAME_RATE_OFFSET = 1724; // film header R32 frame rate (FPS), canonical
+constexpr uint32_t TV_FRAME_RATE_OFFSET = 1940;   // television header R32 frame rate (FPS)
+
+// Pixel layout of the DPX image element that Record/Playback Clip handle.
+struct ImageDesc
+{
+	uint32_t Width = 0;
+	uint32_t Height = 0;
+	uint8_t Channels = 0;                 // 3 = RGB, 4 = RGBA
+	uint8_t BitDepth = 0;                 // 8, 10 or 16
+	uint8_t Transfer = TRANSFER_LINEAR;   // transfer characteristic (CHARACTERISTIC_*)
+	uint8_t Colorimetric = CHARACTERISTIC_UNDEFINED; // colorimetric specification (CHARACTERISTIC_*)
+	float FrameRate = 0.0f;               // frames per second; 0 when the file records no rate
+};
+
+inline uint64_t ImageDataSize(const ImageDesc& d)
+{
+	// 10-bit RGB is stored DPX Method A: one 32-bit word per pixel (3x10 bits + 2 pad).
+	if (d.BitDepth == 10)
+		return uint64_t(d.Width) * d.Height * 4;
+	return uint64_t(d.Width) * d.Height * d.Channels * (d.BitDepth / 8);
+}
+
+// "HH-MM-SS-FF.dpx" file name for a timecode.
+inline std::string TimecodeToFileName(const Timecode& tc)
+{
+	char buf[32];
+	std::snprintf(buf, sizeof(buf), "%02u-%02u-%02u-%02u.dpx",
+		unsigned(tc.hours()), unsigned(tc.minutes()),
+		unsigned(tc.seconds()), unsigned(tc.frames()));
+	return std::string(buf);
+}
+
+namespace detail
+{
+inline void PutU32(uint8_t* p, uint32_t v)
+{
+	p[0] = uint8_t(v); p[1] = uint8_t(v >> 8); p[2] = uint8_t(v >> 16); p[3] = uint8_t(v >> 24);
+}
+inline void PutU16(uint8_t* p, uint16_t v) { p[0] = uint8_t(v); p[1] = uint8_t(v >> 8); }
+inline void PutF32(uint8_t* p, float f) { uint32_t v; std::memcpy(&v, &f, 4); PutU32(p, v); }
+inline uint32_t GetU32(const uint8_t* p, bool be)
+{
+	return be ? (uint32_t(p[0]) << 24 | uint32_t(p[1]) << 16 | uint32_t(p[2]) << 8 | p[3])
+			  : (uint32_t(p[3]) << 24 | uint32_t(p[2]) << 16 | uint32_t(p[1]) << 8 | p[0]);
+}
+inline uint16_t GetU16(const uint8_t* p, bool be)
+{
+	return be ? uint16_t(uint16_t(p[0]) << 8 | p[1]) : uint16_t(uint16_t(p[1]) << 8 | p[0]);
+}
+inline float GetF32(const uint8_t* p, bool be) { uint32_t v = GetU32(p, be); float f; std::memcpy(&f, &v, 4); return f; }
+} // namespace detail
+
+// Builds a little-endian DPX header into `out` (HEADER_SIZE bytes), embedding `tc` as the
+// SMPTE timecode in the television header. `frameRate` (FPS) is written to both standard
+// frame-rate fields so the HH:MM:SS:FF timecode is unambiguous; pass <= 0 to leave it unset.
+inline void WriteHeader(uint8_t* out, const ImageDesc& d, const Timecode& tc, float frameRate)
+{
+	using namespace detail;
+	std::memset(out, 0, HEADER_SIZE);
+
+	// File information header.
+	std::memcpy(out, "XPDS", 4);                  // magic - little-endian DPX
+	PutU32(out + 4, HEADER_SIZE);                 // offset to image data
+	std::memcpy(out + 8, "V2.0", 4);              // version
+	PutU32(out + 16, uint32_t(HEADER_SIZE + ImageDataSize(d))); // total file size
+	PutU32(out + 20, 1);                          // ditto key
+	PutU32(out + 24, 1664);                       // generic header length
+	PutU32(out + 28, 384);                        // industry header length
+	PutU32(out + 32, 0);                          // user header length
+	std::memcpy(out + 160, "Nodos WriteDPX", 14); // creator
+	PutU32(out + 660, 0xFFFFFFFFu);               // encryption key - unencrypted
+
+	// Image information header.
+	PutU16(out + 768, 0);                         // orientation - top-left origin
+	PutU16(out + 770, 1);                         // number of image elements
+	PutU32(out + 772, d.Width);
+	PutU32(out + 776, d.Height);
+	uint8_t* e = out + 780;                       // image element 1
+	PutU32(e + 0, 0);                             // data sign - unsigned
+	PutU32(e + 4, 0);                             // reference low data
+	PutF32(e + 8, 0.0f);                          // reference low quantity
+	uint32_t refHigh = d.BitDepth == 16 ? 65535u : (d.BitDepth == 10 ? 1023u : 255u);
+	PutU32(e + 12, refHigh);                      // reference high data
+	PutF32(e + 16, 1.0f);                         // reference high quantity
+	e[20] = d.Channels == 4 ? 51 : 50;            // descriptor - RGBA / RGB
+	e[21] = d.Transfer;                           // transfer characteristic
+	e[22] = d.Colorimetric;                       // colorimetric specification
+	e[23] = d.BitDepth;                           // bit depth
+	// Packing: 10-bit RGB is filled to 32-bit words (Method A); 8/16-bit are tightly packed.
+	PutU16(e + 24, d.BitDepth == 10 ? 1 : 0);     // packing
+	PutU16(e + 26, 0);                            // encoding - uncompressed
+	PutU32(e + 28, HEADER_SIZE);                  // offset to data
+	PutU32(e + 32, 0);                            // end-of-line padding
+	PutU32(e + 36, 0);                            // end-of-image padding
+
+	// Television information header - SMPTE timecode, BCD-packed as 0xHHMMSSFF.
+	auto bcd = [](unsigned v) { return uint32_t(((v / 10) << 4) | (v % 10)); };
+	PutU32(out + 1920, (bcd(tc.hours()) << 24) | (bcd(tc.minutes()) << 16)
+					   | (bcd(tc.seconds()) << 8) | bcd(tc.frames()));
+	// Frame rate the FF field counts against, written to both standard R32 fields (the film
+	// header's canonical field and the television header's). 0 means unknown (variable-step).
+	if (frameRate > 0.0f)
+	{
+		PutF32(out + FILM_FRAME_RATE_OFFSET, frameRate);
+		PutF32(out + TV_FRAME_RATE_OFFSET, frameRate);
+	}
+}
+
+// Parses a DPX header (`hdr` must hold at least HEADER_SIZE bytes). Returns false for a
+// non-DPX, RLE-encoded, or otherwise unsupported file.
+inline bool ReadHeader(const uint8_t* hdr, ImageDesc& d, uint32_t& dataOffset, bool& bigEndian)
+{
+	using namespace detail;
+	if (std::memcmp(hdr, "SDPX", 4) == 0) bigEndian = true;
+	else if (std::memcmp(hdr, "XPDS", 4) == 0) bigEndian = false;
+	else return false;
+
+	dataOffset = GetU32(hdr + 4, bigEndian);
+	if (dataOffset < 1664)
+		return false;
+	d.Width = GetU32(hdr + 772, bigEndian);
+	d.Height = GetU32(hdr + 776, bigEndian);
+
+	const uint8_t* e = hdr + 780;
+	if (GetU16(e + 26, bigEndian) != 0)           // encoding - reject RLE
+		return false;
+	uint8_t descriptor = e[20];
+	if (descriptor == 51) d.Channels = 4;
+	else if (descriptor == 50) d.Channels = 3;
+	else return false;
+	uint8_t bitDepth = e[23];
+	if (bitDepth != 8 && bitDepth != 16)
+		return false;
+	d.BitDepth = bitDepth;
+	d.Transfer = e[21];
+	d.Colorimetric = e[22];
+	d.FrameRate = GetF32(hdr + FILM_FRAME_RATE_OFFSET, bigEndian); // canonical frame rate (0 when unset)
+	return d.Width != 0 && d.Height != 0;
+}
+
+} // namespace nos::mediaio::dpx

--- a/Source/ExtractTimecode.cpp
+++ b/Source/ExtractTimecode.cpp
@@ -1,0 +1,210 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+#include <algorithm>
+#include <climits>
+#include <cmath>
+#include <cstdint>
+
+#include "nosMediaio/ANC_generated.h"
+#include "Timing.hpp"
+
+namespace nos::mediaio
+{
+
+namespace
+{
+struct DecodedTC
+{
+	uint8_t Hours;
+	uint8_t Minutes;
+	uint8_t Seconds;
+	uint8_t Frames;
+	bool DropFrame;
+	bool ColorFrame;
+	uint8_t DBB1Type; // bits 2-0 of DBB1: 0=LTC, 1=VITC1, 2=VITC2, ...
+	uint8_t FieldID;  // HFR pair-encoding field flag (0/1); always 0 below 40 fps.
+};
+
+// SMPTE ST 12-2 ATC payload layout (16 user data words, one byte per UDW).
+// TC nibbles live in the HIGH nibble of even-indexed bytes; BG nibbles live
+// in the HIGH nibble of odd-indexed bytes; DBB1/DBB2 are reconstructed from
+// bit 3 of each UDW (LSB first), DBB1 from bytes 0-7, DBB2 from bytes 8-15.
+//   [0]  frame units            [1]  BG1
+//   [2]  frame tens + DF + CF   [3]  BG2
+//   [4]  second units           [5]  BG3
+//   [6]  second tens + BG flag  [7]  BG4
+//   [8]  minute units           [9]  BG5
+//   [10] minute tens + BG flag  [11] BG6
+//   [12] hour units             [13] BG7
+//   [14] hour tens + flags      [15] BG8
+//
+// HFR FieldID (frame rates >= 40 fps, ST 12-1:2014 Section 12.1): the wire
+// frame field carries half the actual frame count (0..30) and a 1-bit
+// FieldID picks even/odd of the pair. Symmetric with InjectTimecode's
+// EncodeATCPayload — bit position depends on family and DBB1Type:
+//   PAL family (25/50) + VITC carriage (DBB1=1/2): bit 7 of UDW2  (out[2])
+//   PAL family (25/50) + LTC carriage  (DBB1=0):   bit 7 of UDW14 (out[14])
+//   NTSC family / 48:                              bit 7 of UDW6  (out[6])
+bool DecodeATCPayload(const uint8_t* p, size_t n, int fpsRound, DecodedTC& out)
+{
+	if (!p || n < 16)
+		return false;
+	auto hi = [&](size_t i) -> uint8_t { return uint8_t((p[i] >> 4) & 0x0F); };
+	const uint8_t frameTens = hi(2);
+	const uint8_t secTens   = hi(6);
+	const uint8_t minTens   = hi(10);
+	const uint8_t hourTens  = hi(14);
+	uint8_t frames = uint8_t(hi(0) + (frameTens & 0x3) * 10);
+	out.DropFrame  = (frameTens & 0x4) != 0;
+	out.ColorFrame = (frameTens & 0x8) != 0;
+	out.Seconds    = uint8_t(hi(4)  + (secTens   & 0x7) * 10);
+	out.Minutes    = uint8_t(hi(8)  + (minTens   & 0x7) * 10);
+	out.Hours      = uint8_t(hi(12) + (hourTens  & 0x3) * 10);
+
+	// DBB1 bits 2-0 identify the ATC flavor (0=LTC, 1=VITC1, 2=VITC2). Each DBB
+	// bit is bit 3 of one UDW, packed LSB-first across UDW1..UDW8.
+	uint8_t dbb1 = 0;
+	for (int i = 0; i < 8; ++i)
+	{
+		dbb1 = uint8_t(dbb1 >> 1);
+		dbb1 = uint8_t(dbb1 | ((p[i] << 4) & 0x80));
+	}
+	out.DBB1Type = uint8_t(dbb1 & 0x07);
+
+	if (fpsRound >= 40)
+	{
+		const bool isPalFamily = (fpsRound == 25 || fpsRound == 50);
+		const bool isVITC = (out.DBB1Type == 1 || out.DBB1Type == 2);
+		uint8_t fieldID = 0;
+		if (isPalFamily && isVITC)
+			fieldID = (p[2]  & 0x80) ? 1u : 0u;
+		else if (isPalFamily)
+			fieldID = (p[14] & 0x80) ? 1u : 0u;
+		else
+			fieldID = (p[6]  & 0x80) ? 1u : 0u;
+		out.FieldID = fieldID;
+		out.Frames  = uint8_t(frames * 2 + fieldID);
+	}
+	else
+	{
+		out.FieldID = 0;
+		out.Frames  = frames;
+	}
+
+	return out.Hours < 24 && out.Minutes < 60 && out.Seconds < 60 && out.Frames < uint8_t(fpsRound);
+}
+
+bool MatchesSource(uint8_t dbb1Type, ATCSource source)
+{
+	switch (source)
+	{
+	case ATCSource::ATC_LTC:   return dbb1Type == 0;
+	case ATCSource::ATC_VITC1: return dbb1Type == 1;
+	case ATCSource::ATC_VITC2: return dbb1Type == 2;
+	case ATCSource::Auto:
+	default:                   return true;
+	}
+}
+
+int AutoPriority(uint8_t dbb1Type)
+{
+	// Prefer LTC, then VITC1, then VITC2, then anything else.
+	switch (dbb1Type)
+	{
+	case 0: return 0;
+	case 1: return 1;
+	case 2: return 2;
+	default: return 3;
+	}
+}
+
+ATCSource DBB1TypeToSource(uint8_t dbb1Type)
+{
+	switch (dbb1Type)
+	{
+	case 1:  return ATCSource::ATC_VITC1;
+	case 2:  return ATCSource::ATC_VITC2;
+	default: return ATCSource::ATC_LTC;
+	}
+}
+} // namespace
+
+struct ExtractTimecodeNode : NodeContext
+{
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		const ANCFrame* frame = params.GetPinValue<ANCFrame>(NOS_NAME_STATIC("ANCFrame"));
+		const auto source = *params.GetPinValue<ATCSource>(NOS_NAME_STATIC("Source"));
+
+		// Frame rate: prefer the explicit override pin (>0); otherwise infer from the
+		// path's fixed-step timing, falling back to 60 on variable-step paths.
+		float frameRate = *params.GetPinValue<float>(NOS_NAME_STATIC("FrameRateOverride"));
+		if (frameRate <= 0.0f)
+			frameRate = FrameRateFromTiming(params.RawParams, 60.0f);
+
+		const int fpsRound = std::max(1, int(std::lround(frameRate)));
+		// Drop-frame is only defined for the NTSC fractional rates (29.97 /
+		// 59.94). If a foreign device misencodes DF=1 on an integer-rate
+		// timeline, ignore the flag in the emitted Timecode so consumers don't
+		// apply NTSC drop-math to a non-NTSC stream.
+		const bool isNtscFamily =
+			std::abs(frameRate - 29.97f) < 0.05f ||
+			std::abs(frameRate - 59.94f) < 0.05f;
+
+		DecodedTC best{};
+		int bestPriority = INT_MAX;
+		bool found = false;
+
+		if (frame && frame->packets())
+		{
+			for (const auto* pkt : *frame->packets())
+			{
+				// SMPTE ST 12-2 ATC: DID=0x60, SDID=0x60.
+				if (!pkt || pkt->did() != 0x60 || pkt->sdid() != 0x60)
+					continue;
+				const auto* payload = pkt->payload();
+				if (!payload)
+					continue;
+				DecodedTC tc{};
+				if (!DecodeATCPayload(payload->data(), payload->size(), fpsRound, tc))
+					continue;
+				if (!MatchesSource(tc.DBB1Type, source))
+					continue;
+				const int prio = (source == ATCSource::Auto) ? AutoPriority(tc.DBB1Type) : 0;
+				if (!found || prio < bestPriority)
+				{
+					best = tc;
+					bestPriority = prio;
+					found = true;
+					if (source != ATCSource::Auto)
+						break; // exact match, no need to keep scanning
+				}
+			}
+		}
+
+		if (found)
+		{
+			const bool effectiveDropFrame = best.DropFrame && isNtscFamily;
+			Timecode out(best.Hours, best.Minutes, best.Seconds, best.Frames,
+				effectiveDropFrame, DBB1TypeToSource(best.DBB1Type));
+			SetPinValue(NOS_NAME_STATIC("Timecode"), nos::Buffer::From(out));
+			SetPinValue(NOS_NAME_STATIC("Valid"), nos::Buffer::From(true));
+		}
+		else
+		{
+			SetPinValue(NOS_NAME_STATIC("Valid"), nos::Buffer::From(false));
+		}
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterExtractTimecode(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("ExtractTimecode"), ExtractTimecodeNode, fn)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Source/InjectTimecode.cpp
+++ b/Source/InjectTimecode.cpp
@@ -1,0 +1,228 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "nosMediaio/ANC_generated.h"
+#include "Timing.hpp"
+
+namespace nos::mediaio
+{
+
+namespace
+{
+uint8_t SourceToDBB1Type(ATCSource source)
+{
+	switch (source)
+	{
+	case ATCSource::ATC_VITC1: return 1;
+	case ATCSource::ATC_VITC2: return 2;
+	case ATCSource::ATC_LTC:
+	case ATCSource::Auto:
+	default:                   return 0;
+	}
+}
+
+// 16-byte SMPTE ST 12-2 payload: TC nibbles in HIGH nibble of even bytes, BG
+// nibbles in HIGH nibble of odd bytes (we leave BG zero), DBB1 packed across
+// bytes 0-7 / DBB2 across 8-15 — bit 3 of each UDW, LSB first.
+//
+// For frame rates >= 40 fps (SMPTE ST 12-1:2014 Section 12.1, HFR pair
+// encoding), the on-wire frame field can only represent 0..30, so each TC
+// value is shared by two consecutive video frames and a Field Identification
+// bit toggles between them. The wire frame number is `frames / 2`, and the
+// FieldID (= `frames % 2`) goes at a bit position that depends on both frame
+// family and carriage (LTC vs VITC):
+//
+//   PAL family (25/50 fps):
+//     - LTC carriage    (DBB1Type=0): LTC  bit 59 → UDW14 bit 7  [Table 3]
+//     - VITC carriage   (DBB1Type=1/2): VITC bit 15 → UDW2  bit 7  [Table 7]
+//   NTSC family (30/60 fps) and 48 fps:
+//     - LTC and VITC both land at UDW6 bit 7 (LTC bit 27 / VITC bit 35).
+//
+// AJA's AJAAncillaryData_Timecode::SetFieldIdFlag uses the LTC bit position
+// regardless of DBB1Type, which ST 12-1 Section 12.2 (Informative) calls out
+// as one of "various implementations" that exist. We follow strict ST 12-1
+// here so spec-conformant receivers will decode VITC field flag.
+void EncodeATCPayload(uint8_t hours, uint8_t minutes, uint8_t seconds, uint8_t frames,
+	bool dropFrame, uint8_t dbb1Type, int fpsRound, bool isPalFamily, uint8_t out[16])
+{
+	std::memset(out, 0, 16);
+
+	const bool isHFR = fpsRound >= 40;
+	uint8_t wireFrames = frames;
+	uint8_t fieldID = 0;
+	if (isHFR)
+	{
+		fieldID = uint8_t(frames & 0x1);
+		wireFrames = uint8_t(frames / 2);
+	}
+
+	const uint8_t frameUnits = uint8_t(wireFrames % 10);
+	const uint8_t frameTens  = uint8_t((wireFrames / 10) & 0x3) | (dropFrame ? 0x4 : 0x0);
+	const uint8_t secUnits   = uint8_t(seconds % 10);
+	const uint8_t secTens    = uint8_t((seconds / 10) & 0x7);
+	const uint8_t minUnits   = uint8_t(minutes % 10);
+	const uint8_t minTens    = uint8_t((minutes / 10) & 0x7);
+	const uint8_t hourUnits  = uint8_t(hours % 10);
+	const uint8_t hourTens   = uint8_t((hours / 10) & 0x3);
+
+	out[0]  = uint8_t(frameUnits << 4);
+	out[2]  = uint8_t(frameTens  << 4);
+	out[4]  = uint8_t(secUnits   << 4);
+	out[6]  = uint8_t(secTens    << 4);
+	out[8]  = uint8_t(minUnits   << 4);
+	out[10] = uint8_t(minTens    << 4);
+	out[12] = uint8_t(hourUnits  << 4);
+	out[14] = uint8_t(hourTens   << 4);
+
+	if (isHFR && fieldID)
+	{
+		const bool isVITC = (dbb1Type == 1 || dbb1Type == 2);
+		if (isPalFamily && isVITC)
+			out[2]  = uint8_t(out[2]  | 0x80);  // VITC bit 15 (25-frame)
+		else if (isPalFamily)
+			out[14] = uint8_t(out[14] | 0x80);  // LTC bit 59 (25-frame)
+		else
+			out[6]  = uint8_t(out[6]  | 0x80);  // LTC bit 27 / VITC bit 35 (30-frame)
+	}
+
+	const uint8_t dbb1 = uint8_t(dbb1Type & 0x07);
+	for (int i = 0; i < 8; ++i)
+	{
+		if ((dbb1 >> i) & 0x01)
+			out[i] = uint8_t(out[i] | 0x08);
+	}
+}
+} // namespace
+
+struct InjectTimecodeNode : NodeContext
+{
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		const ANCFrame* in = params.GetPinValue<ANCFrame>(NOS_NAME_STATIC("ANCFrame"));
+		const Timecode* tc = params.GetPinValue<Timecode>(NOS_NAME_STATIC("Timecode"));
+		if (!tc)
+			return NOS_RESULT_FAILED;
+
+		float frameRate = *params.GetPinValue<float>(NOS_NAME_STATIC("FrameRateOverride"));
+		if (frameRate <= 0.0f)
+			frameRate = FrameRateFromTiming(params.RawParams, 60.0f);
+
+		const uint8_t dbb1Type = SourceToDBB1Type(tc->source());
+		const int fpsRound = std::max(1, int(std::lround(frameRate)));
+		// PAL family per CRP188::FormatIsPAL (25/50 fps) puts the HFR FieldID
+		// at LTC bit 59; everything else (including 48 and 60) puts it at LTC
+		// bit 27. Only matters when fpsRound >= 40.
+		const bool isPalFamily = (fpsRound == 25 || fpsRound == 50);
+
+		uint8_t payload[16];
+		EncodeATCPayload(tc->hours(), tc->minutes(), tc->seconds(), tc->frames(),
+			tc->drop_frame(), dbb1Type, fpsRound, isPalFamily, payload);
+
+		// SMPTE ST 12-2 / RP-188 places ATC on a single field per packet:
+		//   LTC   (DBB1=0): F1 — describes the whole frame.
+		//   VITC1 (DBB1=1): F1.
+		//   VITC2 (DBB1=2): F2 (the F2-line VITC).
+		// On progressive output the F2 distinction is degenerate; downstream
+		// WriteAnc collapses is_field2=true to F1 when not interlaced.
+		const bool emitField2 = (dbb1Type == 2);
+
+		flatbuffers::FlatBufferBuilder fbb;
+		std::vector<flatbuffers::Offset<ANCPacket>> packets;
+
+		// Forward incoming packets, dropping any existing ATC of the same flavor
+		// (DID=0x60/SDID=0x60, same DBB1Type) ON THE SAME FIELD so we don't
+		// double-emit. ATC on the other field is forwarded untouched.
+		if (in && in->packets())
+		{
+			const auto* incoming = in->packets();
+			packets.reserve(incoming->size() + 1);
+			for (uint32_t i = 0; i < incoming->size(); ++i)
+			{
+				const auto* src = incoming->Get(i);
+				if (!src)
+					continue;
+				if (src->did() == 0x60 && src->sdid() == 0x60 && src->is_field2() == emitField2)
+				{
+					const auto* p = src->payload();
+					if (p && p->size() >= 16)
+					{
+						uint8_t existingDbb1 = 0;
+						for (int b = 0; b < 8; ++b)
+						{
+							existingDbb1 = uint8_t(existingDbb1 >> 1);
+							existingDbb1 = uint8_t(existingDbb1 | ((p->Get(b) << 4) & 0x80));
+						}
+						if ((existingDbb1 & 0x07) == dbb1Type)
+							continue;
+					}
+				}
+				const auto* p = src->payload();
+				const uint8_t* pdata = p ? p->data() : nullptr;
+				const size_t psize = p ? p->size() : 0;
+				auto payloadOffset = fbb.CreateVector(pdata, psize);
+				ANCPacketBuilder pb(fbb);
+				pb.add_did(src->did());
+				pb.add_sdid(src->sdid());
+				pb.add_line_number(src->line_number());
+				pb.add_horiz_offset(src->horiz_offset());
+				pb.add_space(src->space());
+				pb.add_channel(src->channel());
+				pb.add_link(src->link());
+				pb.add_stream(src->stream());
+				pb.add_is_field2(src->is_field2());
+				pb.add_payload(payloadOffset);
+				packets.push_back(pb.Finish());
+			}
+		}
+		else
+		{
+			packets.reserve(1);
+		}
+
+		// VANC line 10, Y (luma), Link A, horiz_offset 0 — matches AJA's
+		// ntv2llburn reference for transmitted ATC packets (see ntv2llburn.cpp
+		// F1AncDataLoc) and SMPTE ST 12M-2, which specifies ATC-LTC in VANC.
+		// The HANC/AnyHanc placement that lived here previously matched AJA's
+		// AJAAncillaryData_Timecode_ATC::GeneratePayloadData internal default,
+		// but the AJA hardware ANC inserter doesn't surface those packets to
+		// downstream SDI monitors — extractors (incl. ours) find camera ATC
+		// in VANC, so the inserter has to write there too for round-trip
+		// compatibility.
+		auto atcPayload = fbb.CreateVector(payload, 16);
+		ANCPacketBuilder pb(fbb);
+		pb.add_did(0x60);
+		pb.add_sdid(0x60);
+		pb.add_line_number(10);
+		pb.add_horiz_offset(0);
+		pb.add_space(ANCDataSpace::VANC);
+		pb.add_channel(ANCDataChannel::Y);
+		pb.add_link(ANCDataLink::A);
+		pb.add_is_field2(emitField2);
+		pb.add_payload(atcPayload);
+		packets.push_back(pb.Finish());
+
+		auto packetsVec = fbb.CreateVector(packets);
+		ANCFrameBuilder frameBuilder(fbb);
+		frameBuilder.add_packets(packetsVec);
+		fbb.Finish(frameBuilder.Finish());
+
+		SetPinValue(NOS_NAME_STATIC("Out"), nos::Buffer(fbb.Release()));
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterInjectTimecode(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("InjectTimecode"), InjectTimecodeNode, fn)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Source/Interlace.cpp
+++ b/Source/Interlace.cpp
@@ -22,6 +22,12 @@ struct InterlaceNode : NodeContext
 {
 	nosTextureFieldType Field;
 
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		SetNodeStatusMessage("Internal - not intended for use.", fb::NodeStatusMessageType::WARNING);
+		return NOS_RESULT_SUCCESS;
+	}
+
 	nosResult CopyFrom(nosCopyFromInfo* copyInfo) override
 	{
 		nosVulkan->SetResourceFieldType(*copyInfo->PinObjectHandle, Field);
@@ -85,6 +91,13 @@ struct FieldJugglerNode : NodeContext
 
 struct DeinterlaceNode : NodeContext
 {
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		SetNodeStatusMessage("Deprecated: low-quality single-field deinterlace.\nUse YADIF instead.",
+							 fb::NodeStatusMessageType::WARNING);
+		return NOS_RESULT_SUCCESS;
+	}
+
 	nosResult CopyFrom(nosCopyFromInfo* copyInfo) override
 	{
 		nosVulkan->SetResourceFieldType(*copyInfo->PinObjectHandle, NOS_TEXTURE_FIELD_TYPE_PROGRESSIVE);

--- a/Source/MediaIOAPI.cpp
+++ b/Source/MediaIOAPI.cpp
@@ -74,6 +74,23 @@ nosMediaIOVideoScanType NOSAPI_CALL GetVideoScanTypeFromString(const char* str)
 	return NOS_MEDIAIO_VIDEO_SCAN_TYPE_INVALID;
 }
 
+nosMediaIOVideoConnectionType NOSAPI_CALL GetVideoConnectionTypeFromString(const char* str)
+{
+	for (size_t i = NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_MIN; i <= NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_MAX; ++i)
+	{
+		if (strcmp(str, NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_NAMES[i]) == 0)
+			return static_cast<nosMediaIOVideoConnectionType>(i);
+	}
+	return NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_INVALID;
+}
+
+const char* NOSAPI_CALL GetVideoConnectionTypeName(nosMediaIOVideoConnectionType connectionType)
+{
+	if (connectionType < NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_MIN || connectionType > NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_MAX)
+		return NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_NAMES[NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_INVALID];
+	return NOS_MEDIAIO_VIDEO_CONNECTION_TYPE_NAMES[connectionType];
+}
+
 nosResult NOSAPI_CALL GetFrameRateDeltaSeconds(nosMediaIOFrameRate frameRate, nosVec2u* outDeltaSeconds)
 {
 	if (outDeltaSeconds == nullptr)
@@ -163,6 +180,8 @@ nosResult NOSAPI_CALL Export(uint32_t minorVersion, void** outAPI)
 	api->Get2DFrameResolution = Get2DFrameResolution;
 	api->GetVideoScanTypeName = GetVideoScanTypeName;
 	api->GetVideoScanTypeFromString = GetVideoScanTypeFromString;
+	api->GetVideoConnectionTypeName = GetVideoConnectionTypeName;
+	api->GetVideoConnectionTypeFromString = GetVideoConnectionTypeFromString;
 	*outAPI = api;
 	GExportedAPIVersions[minorVersion] = api;
 	return NOS_RESULT_SUCCESS;

--- a/Source/MediaIOMain.cpp
+++ b/Source/MediaIOMain.cpp
@@ -27,10 +27,21 @@ enum Nodes : int
 	YUVBufferSizeCalculator,
 	GammaLUT,
 	ColorSpaceMatrix,
+	TextureToBuffer,
 	YUY2ToRGBA,
 	NV12ToRGBA,
 	FieldJuggler,
 	Debayer,
+	ExtractTimecode,
+	InjectTimecode,
+	TimecodeFromFrameNumber,
+	TimecodeToFrameNumber,
+	TimecodeToString,
+	TimecodePlayer,
+	SLog3ToLinear,
+	LinearToSLog3,
+	WriteDPX,
+	PlaybackClip,
 	StbiLoad,
 	WriteImage,
 	LoadCubeLUT,
@@ -49,6 +60,17 @@ nosResult RegisterYUY2ToRGBA(nosNodeFunctions*);
 nosResult RegisterNV12ToRGBA(nosNodeFunctions*);
 nosResult RegisterFieldJuggler(nosNodeFunctions*);
 nosResult RegisterDebayer(nosNodeFunctions*);
+nosResult RegisterTextureToBuffer(nosNodeFunctions*);
+nosResult RegisterExtractTimecode(nosNodeFunctions*);
+nosResult RegisterInjectTimecode(nosNodeFunctions*);
+nosResult RegisterTimecodeFromFrameNumber(nosNodeFunctions*);
+nosResult RegisterTimecodeToFrameNumber(nosNodeFunctions*);
+nosResult RegisterTimecodeToString(nosNodeFunctions*);
+nosResult RegisterTimecodePlayer(nosNodeFunctions*);
+nosResult RegisterSLog3ToLinear(nosNodeFunctions*);
+nosResult RegisterLinearToSLog3(nosNodeFunctions*);
+nosResult RegisterWriteDPX(nosNodeFunctions*);
+nosResult RegisterPlaybackClip(nosNodeFunctions*);
 
 } // namespace nos::mediaio
 
@@ -91,10 +113,21 @@ struct MediaIOPluginFunctions : nos::PluginFunctions
 				GEN_CASE_NODE(YUVBufferSizeCalculator)
 				GEN_CASE_NODE(GammaLUT)
 				GEN_CASE_NODE(ColorSpaceMatrix)
+				GEN_CASE_NODE(TextureToBuffer)
 				GEN_CASE_NODE(YUY2ToRGBA)
 				GEN_CASE_NODE(NV12ToRGBA)
 				GEN_CASE_NODE(FieldJuggler)
 				GEN_CASE_NODE(Debayer)
+				GEN_CASE_NODE(ExtractTimecode)
+				GEN_CASE_NODE(InjectTimecode)
+				GEN_CASE_NODE(TimecodeFromFrameNumber)
+				GEN_CASE_NODE(TimecodeToFrameNumber)
+				GEN_CASE_NODE(TimecodeToString)
+				GEN_CASE_NODE(TimecodePlayer)
+				GEN_CASE_NODE(SLog3ToLinear)
+				GEN_CASE_NODE(LinearToSLog3)
+				GEN_CASE_NODE(WriteDPX)
+				GEN_CASE_NODE(PlaybackClip)
 				GEN_CASE_NODE(StbiLoad)
 				GEN_CASE_NODE(WriteImage)
 				GEN_CASE_NODE(LoadCubeLUT)

--- a/Source/PlaybackClip.cpp
+++ b/Source/PlaybackClip.cpp
@@ -1,0 +1,215 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosSysVulkan/Helpers.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "nosMediaio/ANC_generated.h"
+#include "Dpx.h"
+#include "Timing.hpp"
+
+namespace nos::mediaio
+{
+
+// Plays back a clip written by WriteDPX: for the incoming timecode it loads the
+// matching 'HH-MM-SS-FF.dpx' frame from Path and emits it on the Texture output. The
+// output texture format follows the DPX transfer tag - an sRGB-encoded file becomes an
+// _SRGB texture so the graph's sampler decodes it back to linear automatically. When no
+// frame matches the timecode, the last loaded frame is held. Progress and errors are
+// surfaced on the node status.
+struct PlaybackClipNode : NodeContext
+{
+	TypedObjectRef<sys::vulkan::Texture> OutputTexture;
+	std::string LoadedFrame;          // file name currently held on the output pin
+	nosVec2u LoadedResolution = {};   // held frame's resolution
+	float LoadedFrameRate = 0.0f;     // frame rate recorded in the held frame's header (0 = unset)
+	std::string StatusText;
+	int StatusType = -1;
+
+
+	// Sets the node status, skipping the update when nothing changed.
+	void ShowStatus(const std::string& text, fb::NodeStatusMessageType type)
+	{
+		if (int(type) == StatusType && text == StatusText)
+			return;
+		StatusText = text;
+		StatusType = int(type);
+		SetNodeStatusMessage(text, type);
+	}
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		const Timecode* tc = params.GetPinValue<Timecode>(NOS_NAME_STATIC("Timecode"));
+		if (!tc)
+		{
+			ShowStatus("Missing Timecode input", fb::NodeStatusMessageType::WARNING);
+			return NOS_RESULT_SUCCESS; // hold last frame
+		}
+
+		const char* pathC = params.GetPinValue<const char*>(NOS_NAME_STATIC("Path"));
+		if (!pathC)
+			pathC = "";
+		if (!*pathC)
+		{
+			ShowStatus("Set input directory", fb::NodeStatusMessageType::WARNING);
+			return NOS_RESULT_SUCCESS; // hold last frame
+		}
+
+		std::string fileName = dpx::TimecodeToFileName(*tc);
+		if (fileName == LoadedFrame && OutputTexture.IsValid())
+		{
+			// Already holding this frame, but re-check timing so a cadence change still warns.
+			ReportPlaybackStatus(params.RawParams, fileName);
+			return NOS_RESULT_SUCCESS;
+		}
+
+		std::filesystem::path filePath = nos::Utf8ToPath(std::string(pathC)) / fileName;
+		std::error_code ec;
+		if (!std::filesystem::exists(filePath, ec))
+		{
+			ShowStatus(fileName + " not found - holding last frame",
+				fb::NodeStatusMessageType::WARNING);
+			return NOS_RESULT_SUCCESS; // hold last frame
+		}
+
+		if (LoadFrame(filePath))
+		{
+			LoadedFrame = fileName;
+			ReportPlaybackStatus(params.RawParams, fileName);
+		}
+		return NOS_RESULT_SUCCESS; // load failure also holds the last frame
+	}
+
+	// Shows "Playing <file> - 1920x1080 @ 59.94 FPS", warning when the executing path can't
+	// reproduce the clip's recorded frame rate. DPX stores the rate as a float, so the compare uses
+	// a small tolerance - enough to tell 59.94 from 60. A variable-step path has no fixed rate and
+	// always warns; a fixed-step path warns only when its rate differs. A clip with no recorded rate
+	// (0) and a 0/0 path delta are both left unchecked.
+	void ReportPlaybackStatus(const nosNodeExecuteParams* params, const std::string& fileName)
+	{
+		// "Playing <file> - 1920x1080 @ 59.94 FPS" (FPS omitted when the clip records no rate).
+		std::string info = "Playing " + fileName + " - "
+			+ std::to_string(LoadedResolution.x) + "x" + std::to_string(LoadedResolution.y);
+		if (LoadedFrameRate > 0.0f)
+			info += " @ " + FrameRateToString(LoadedFrameRate) + " FPS";
+
+		if (LoadedFrameRate > 0.0f)
+		{
+			// A variable-step path can't reproduce a fixed recorded rate; always warn.
+			if (params->TimingInfo.TimingMode != NOS_EXECUTION_TIMING_MODE_FIXED_STEP)
+			{
+				ShowStatus(info + " - timing mismatch: path is variable-step",
+					fb::NodeStatusMessageType::WARNING);
+				return;
+			}
+			// 0 here means the fixed-step path has no nominal rate yet - skip the check.
+			float pathRate = FrameRateFromTiming(params);
+			if (pathRate > 0.0f && std::fabs(pathRate - LoadedFrameRate) > 0.01f)
+			{
+				ShowStatus(info + " - timing mismatch: path " + FrameRateToString(pathRate) + " FPS",
+					fb::NodeStatusMessageType::WARNING);
+				return;
+			}
+		}
+
+		ShowStatus(info, fb::NodeStatusMessageType::INFO);
+	}
+
+	bool LoadFrame(const std::filesystem::path& filePath)
+	{
+		std::string utf8Path = nos::PathToUtf8(filePath);
+		std::string fileName = nos::PathToUtf8(filePath.filename());
+		std::ifstream file(filePath, std::ios::binary);
+
+		uint8_t header[dpx::HEADER_SIZE];
+		if (!file || !file.read(reinterpret_cast<char*>(header), dpx::HEADER_SIZE))
+		{
+			nosEngine.LogE("PlaybackClip: cannot read %s", utf8Path.c_str());
+			ShowStatus("Cannot read " + fileName, fb::NodeStatusMessageType::FAILURE);
+			return false;
+		}
+
+		dpx::ImageDesc desc;
+		uint32_t dataOffset = 0;
+		bool bigEndian = false;
+		if (!dpx::ReadHeader(header, desc, dataOffset, bigEndian))
+		{
+			nosEngine.LogE("PlaybackClip: %s is not a supported DPX file", utf8Path.c_str());
+			ShowStatus(fileName + " is not a supported DPX file",
+				fb::NodeStatusMessageType::FAILURE);
+			return false;
+		}
+
+		// An sRGB-encoded file loads into an _SRGB texture so the sampler decodes it back
+		// to the graph's linear space; a linear file loads into a plain _UNORM texture.
+		bool linear = desc.Transfer == dpx::TRANSFER_LINEAR;
+		nosFormat format = NOS_FORMAT_NONE;
+		if (desc.Channels == 4)
+		{
+			if (desc.BitDepth == 16) format = NOS_FORMAT_R16G16B16A16_UNORM;
+			else format = linear ? NOS_FORMAT_R8G8B8A8_UNORM : NOS_FORMAT_R8G8B8A8_SRGB;
+		}
+		else if (desc.Channels == 3)
+		{
+			if (desc.BitDepth == 16) format = NOS_FORMAT_R16G16B16_UNORM;
+			else format = linear ? NOS_FORMAT_R8G8B8_UNORM : NOS_FORMAT_R8G8B8_SRGB;
+		}
+		if (format == NOS_FORMAT_NONE)
+		{
+			nosEngine.LogE("PlaybackClip: unsupported DPX pixel layout in %s", utf8Path.c_str());
+			ShowStatus(fileName + " has an unsupported pixel layout",
+				fb::NodeStatusMessageType::FAILURE);
+			return false;
+		}
+
+		std::vector<uint8_t> pixels(dpx::ImageDataSize(desc));
+		file.seekg(dataOffset);
+		if (!file.read(reinterpret_cast<char*>(pixels.data()), std::streamsize(pixels.size())))
+		{
+			nosEngine.LogE("PlaybackClip: %s is truncated", utf8Path.c_str());
+			ShowStatus(fileName + " is truncated", fb::NodeStatusMessageType::FAILURE);
+			return false;
+		}
+		// Our recorder writes little-endian; byte-swap 16-bit samples from big-endian DPX.
+		if (bigEndian && desc.BitDepth == 16)
+			for (size_t i = 0; i + 1 < pixels.size(); i += 2)
+				std::swap(pixels[i], pixels[i + 1]);
+
+		nosTextureInfo texInfo = {.Width = desc.Width, .Height = desc.Height, .Format = format};
+
+		auto texture = sys::vulkan::CreateTexture(texInfo, "PlaybackClip Texture");
+		if (!texture.IsValid())
+		{
+			nosEngine.LogE("PlaybackClip: failed to allocate output texture");
+			ShowStatus("Failed to allocate output texture", fb::NodeStatusMessageType::FAILURE);
+			return false;
+		}
+		nosVulkan->SetResourceFieldType(texture, NOS_TEXTURE_FIELD_TYPE_PROGRESSIVE);
+
+		nosCmd cmd = sys::vulkan::BeginCmd(NOS_NAME("PlaybackClip Upload"), NodeId);
+		nosVulkan->ImageLoad(cmd, pixels.data(), nosVec2u(desc.Width, desc.Height),
+			format, texture, NOS_TEXTURE_FILTER_NEAREST);
+		nosCmdEndParams endParams{ .ForceSubmit = true };
+		nosVulkan->End(cmd, &endParams);
+
+		OutputTexture = std::move(texture);
+		LoadedResolution = {desc.Width, desc.Height};
+		LoadedFrameRate = desc.FrameRate;
+		SetPinObject(NOS_NAME_STATIC("Texture"), OutputTexture);
+		return true;
+	}
+};
+
+nosResult RegisterPlaybackClip(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("PlaybackClip"), PlaybackClipNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Source/TimecodeFromFrameNumber.cpp
+++ b/Source/TimecodeFromFrameNumber.cpp
@@ -1,0 +1,84 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#include "nosMediaio/ANC_generated.h"
+#include "Timing.hpp"
+
+namespace nos::mediaio
+{
+
+namespace
+{
+// Frame-number to HH:MM:SS:FF, with SMPTE drop-frame correction when requested.
+// Standard Andrew Duncan formulation: project N onto a non-DF timeline by adding
+// back the dropped frames, then do plain modular arithmetic with fpsRound.
+void FrameNumberToTC(uint32_t n, float fps, bool dropFrame,
+	uint8_t& outH, uint8_t& outM, uint8_t& outS, uint8_t& outF)
+{
+	const int fpsRound = std::max(1, int(std::lround(fps)));
+	uint32_t projected = n;
+	if (dropFrame)
+	{
+		const int dropPerMin = int(std::lround(fps * 0.066666f));
+		const int framesPerMin = fpsRound * 60 - dropPerMin;
+		const int framesPer10Min = framesPerMin * 10 + dropPerMin;
+		const uint32_t d = n / uint32_t(framesPer10Min);
+		const uint32_t m = n % uint32_t(framesPer10Min);
+		uint32_t addend = uint32_t(dropPerMin) * 9u * d;
+		if (m > uint32_t(dropPerMin))
+			addend += uint32_t(dropPerMin) * ((m - uint32_t(dropPerMin)) / uint32_t(framesPerMin));
+		projected = n + addend;
+	}
+	outF = uint8_t(projected % uint32_t(fpsRound));
+	const uint32_t totalSec = projected / uint32_t(fpsRound);
+	outS = uint8_t(totalSec % 60u);
+	const uint32_t totalMin = totalSec / 60u;
+	outM = uint8_t(totalMin % 60u);
+	outH = uint8_t((totalMin / 60u) % 24u);
+}
+} // namespace
+
+struct TimecodeFromFrameNumberNode : NodeContext
+{
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		const uint32_t frameNumber = *params.GetPinValue<uint32_t>(NOS_NAME_STATIC("FrameNumber"));
+		const bool dropFrame = *params.GetPinValue<bool>(NOS_NAME_STATIC("DropFrame"));
+		const auto source = *params.GetPinValue<ATCSource>(NOS_NAME_STATIC("Source"));
+
+		float frameRate = *params.GetPinValue<float>(NOS_NAME_STATIC("FrameRateOverride"));
+		if (frameRate <= 0.0f)
+			frameRate = FrameRateFromTiming(params.RawParams, 60.0f);
+
+		// Drop-frame is only defined for the NTSC fractional rates (29.97 /
+		// 59.94). Gate on the actual fractional rate (not the rounded value)
+		// so a user at exactly 30.0 or 60.0 fps with DropFrame=true does not
+		// get NTSC drop-math silently applied to an integer-rate timeline.
+		const bool isNtscFamily =
+			std::abs(frameRate - 29.97f) < 0.05f ||
+			std::abs(frameRate - 59.94f) < 0.05f;
+		const bool effectiveDropFrame = dropFrame && isNtscFamily;
+
+		uint8_t h = 0, m = 0, s = 0, f = 0;
+		FrameNumberToTC(frameNumber, frameRate, effectiveDropFrame, h, m, s, f);
+
+		Timecode tc(h, m, s, f, effectiveDropFrame,
+			source == ATCSource::Auto ? ATCSource::ATC_LTC : source);
+		SetPinValue(NOS_NAME_STATIC("Timecode"), nos::Buffer::From(tc));
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterTimecodeFromFrameNumber(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("TimecodeFromFrameNumber"), TimecodeFromFrameNumberNode, fn)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Source/TimecodePlayer.cpp
+++ b/Source/TimecodePlayer.cpp
@@ -1,0 +1,229 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <unordered_map>
+
+#include "nosMediaio/ANC_generated.h"
+#include "Timing.hpp"
+
+namespace nos::mediaio
+{
+
+namespace
+{
+// HH:MM:SS:FF to a frame number, mirroring TimecodeToFrameNumber.
+uint32_t TCToFrameNumber(uint8_t hours, uint8_t minutes, uint8_t seconds, uint8_t frames,
+	float fps, bool dropFrame)
+{
+	const int fpsRound = std::max(1, int(std::lround(fps)));
+	const uint32_t totalSec = (uint32_t(hours) * 60u + minutes) * 60u + seconds;
+	if (!dropFrame)
+		return totalSec * uint32_t(fpsRound) + frames;
+
+	const int dropPerMin = int(std::lround(fps * 0.066666f));
+	const int framesPerMin = fpsRound * 60 - dropPerMin;
+	const int framesPer10Min = framesPerMin * 10 + dropPerMin;
+	const int totalMin = int(hours) * 60 + minutes;
+	return uint32_t(framesPer10Min) * uint32_t(totalMin / 10)
+		+ uint32_t(framesPerMin) * uint32_t(totalMin % 10)
+		+ uint32_t(seconds) * uint32_t(fpsRound)
+		+ frames;
+}
+
+// Frame number to HH:MM:SS:FF, mirroring TimecodeFromFrameNumber.
+void FrameNumberToTC(uint32_t n, float fps, bool dropFrame,
+	uint8_t& outH, uint8_t& outM, uint8_t& outS, uint8_t& outF)
+{
+	const int fpsRound = std::max(1, int(std::lround(fps)));
+	uint32_t projected = n;
+	if (dropFrame)
+	{
+		const int dropPerMin = int(std::lround(fps * 0.066666f));
+		const int framesPerMin = fpsRound * 60 - dropPerMin;
+		const int framesPer10Min = framesPerMin * 10 + dropPerMin;
+		const uint32_t d = n / uint32_t(framesPer10Min);
+		const uint32_t m = n % uint32_t(framesPer10Min);
+		uint32_t addend = uint32_t(dropPerMin) * 9u * d;
+		if (m > uint32_t(dropPerMin))
+			addend += uint32_t(dropPerMin) * ((m - uint32_t(dropPerMin)) / uint32_t(framesPerMin));
+		projected = n + addend;
+	}
+	outF = uint8_t(projected % uint32_t(fpsRound));
+	const uint32_t totalSec = projected / uint32_t(fpsRound);
+	outS = uint8_t(totalSec % 60u);
+	const uint32_t totalMin = totalSec / 60u;
+	outM = uint8_t(totalMin % 60u);
+	outH = uint8_t((totalMin / 60u) % 24u);
+}
+} // namespace
+
+// Matches nos.mediaio.TimecodePlayerMode in TimecodePlayer.fbs.
+enum class TimecodePlayerMode : uint32_t
+{
+	Ranged = 0,
+	Continuous = 1,
+};
+
+// Plays a running timecode, advancing one frame per run while playing. Start/Stop
+// play/pause, Reset returns to Start Time; Ranged mode runs from Start to End then stops.
+struct TimecodePlayerNode : NodeContext
+{
+	uint32_t FrameCounter = 0;
+	bool Playing = false;
+	TimecodePlayerMode Mode = TimecodePlayerMode::Ranged;
+	// Function (Start/Stop/Reset) node ids, keyed by class name, for orphaning controls.
+	std::unordered_map<nos::Name, uuid> FunctionIds;
+
+	nosResult OnCreate(nosFbNodePtr node) override
+	{
+		if (node->pins())
+			for (auto* pin : *node->pins())
+				if (pin->data() && pin->data()->size() &&
+					nos::Name(pin->name()->c_str()) == NOS_NAME_STATIC("Mode"))
+				{
+					const void* data = pin->data()->data();
+					Mode = static_cast<TimecodePlayerMode>(*static_cast<const uint32_t*>(data));
+				}
+		if (node->functions())
+			for (auto* fn : *node->functions())
+				if (fn->class_name() && fn->id())
+					FunctionIds[nos::Name(fn->class_name()->c_str())] = *fn->id();
+		SyncEndTimecodeState();
+		SyncTransportControls();
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void OnPinValueChanged(nos::Name pinName, uuid const&, nosBuffer value) override
+	{
+		if (pinName == NOS_NAME_STATIC("Mode"))
+		{
+			Mode = static_cast<TimecodePlayerMode>(*static_cast<const uint32_t*>(value.Data));
+			SyncEndTimecodeState();
+		}
+	}
+
+	// End Timecode only applies in Ranged mode.
+	void SyncEndTimecodeState()
+	{
+		SetPinOrphanState(NOS_NAME_STATIC("EndTimecode"),
+			Mode == TimecodePlayerMode::Continuous ? fb::PinOrphanStateType::PASSIVE
+												   : fb::PinOrphanStateType::ACTIVE);
+	}
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		const Timecode* start = params.GetPinValue<Timecode>(NOS_NAME_STATIC("StartTime"));
+		if (!start)
+			return NOS_RESULT_FAILED;
+
+		// The player advances one frame per run, so its rate is the rate it is scheduled
+		// at: take it from the path's fixed-step timing (60 fallback if not fixed-step).
+		const float frameRate = FrameRateFromTiming(params.RawParams, 60.0f);
+
+		// Drop-frame is only defined for the NTSC fractional rates (29.97 / 59.94).
+		const bool isNtscFamily =
+			std::abs(frameRate - 29.97f) < 0.05f ||
+			std::abs(frameRate - 59.94f) < 0.05f;
+		const bool effectiveDropFrame = start->drop_frame() && isNtscFamily;
+
+		const uint32_t startFrame = TCToFrameNumber(
+			start->hours(), start->minutes(), start->seconds(), start->frames(),
+			frameRate, effectiveDropFrame);
+
+		uint32_t frame = startFrame + FrameCounter;
+		// In Ranged mode the player runs from Start Time to End Timecode and then stops,
+		// holding the end frame. Continuous mode counts up without bound.
+		bool reachedEnd = false;
+		if (Mode == TimecodePlayerMode::Ranged)
+			if (const Timecode* end = params.GetPinValue<Timecode>(NOS_NAME_STATIC("EndTimecode")))
+			{
+				const uint32_t endFrame = TCToFrameNumber(
+					end->hours(), end->minutes(), end->seconds(), end->frames(),
+					frameRate, effectiveDropFrame);
+				if (endFrame > startFrame && frame >= endFrame)
+				{
+					frame = endFrame;
+					reachedEnd = true;
+				}
+			}
+
+		uint8_t h = 0, m = 0, s = 0, f = 0;
+		FrameNumberToTC(frame, frameRate, effectiveDropFrame, h, m, s, f);
+
+		Timecode tc(h, m, s, f, effectiveDropFrame,
+			start->source() == ATCSource::Auto ? ATCSource::ATC_LTC : start->source());
+		SetPinValue(NOS_NAME_STATIC("Timecode"), nos::Buffer::From(tc));
+
+		if (reachedEnd)
+		{
+			if (Playing)
+				SetPlaying(false);
+		}
+		else if (Playing)
+			++FrameCounter;
+		return NOS_RESULT_SUCCESS;
+	}
+
+	void SetPlaying(bool playing)
+	{
+		Playing = playing;
+		SetPinValue(NOS_NAME_STATIC("Playing"), nos::Buffer::From(playing));
+		SyncTransportControls();
+	}
+
+	// Orphan the control that does not apply to the current state: Start while playing,
+	// Stop while stopped. Node orphan state has no PASSIVE, so ORPHAN is used.
+	void SyncTransportControls()
+	{
+		SetFunctionOrphanState(NOS_NAME_STATIC("Start"),
+			Playing ? fb::NodeOrphanStateType::ORPHAN : fb::NodeOrphanStateType::ACTIVE);
+		SetFunctionOrphanState(NOS_NAME_STATIC("Stop"),
+			Playing ? fb::NodeOrphanStateType::ACTIVE : fb::NodeOrphanStateType::ORPHAN);
+	}
+
+	void SetFunctionOrphanState(nos::Name className, fb::NodeOrphanStateType type)
+	{
+		auto it = FunctionIds.find(className);
+		if (it != FunctionIds.end())
+			SetNodeOrphanState(it->second, type);
+	}
+
+	nosResult Reset(nosFunctionExecuteParams*)
+	{
+		FrameCounter = 0;
+		return NOS_RESULT_SUCCESS;
+	}
+
+	nosResult Start(nosFunctionExecuteParams*)
+	{
+		// Ranged mode plays once from Start to End, so each Start restarts from the beginning.
+		if (Mode == TimecodePlayerMode::Ranged)
+			FrameCounter = 0;
+		SetPlaying(true);
+		return NOS_RESULT_SUCCESS;
+	}
+
+	nosResult Stop(nosFunctionExecuteParams*)
+	{
+		SetPlaying(false);
+		return NOS_RESULT_SUCCESS;
+	}
+
+	NOS_DECLARE_FUNCTIONS(
+		NOS_ADD_FUNCTION(NOS_NAME_STATIC("Reset"), Reset),
+		NOS_ADD_FUNCTION(NOS_NAME_STATIC("Start"), Start),
+		NOS_ADD_FUNCTION(NOS_NAME_STATIC("Stop"), Stop),
+	)
+};
+
+nosResult RegisterTimecodePlayer(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("TimecodePlayer"), TimecodePlayerNode, fn)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Source/TimecodeToFrameNumber.cpp
+++ b/Source/TimecodeToFrameNumber.cpp
@@ -1,0 +1,70 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+
+#include "nosMediaio/ANC_generated.h"
+#include "Timing.hpp"
+
+namespace nos::mediaio
+{
+
+namespace
+{
+uint32_t TCToFrameNumber(uint8_t hours, uint8_t minutes, uint8_t seconds, uint8_t frames,
+	float fps, bool dropFrame)
+{
+	const int fpsRound = std::max(1, int(std::lround(fps)));
+	const uint32_t totalSec = (uint32_t(hours) * 60u + minutes) * 60u + seconds;
+	if (!dropFrame)
+		return totalSec * uint32_t(fpsRound) + frames;
+
+	// SMPTE drop-frame: drop 2 frames at the start of every minute except every
+	// 10th minute (29.97). Scales linearly with rate (4 dropped per minute at 59.94).
+	const int dropPerMin = int(std::lround(fps * 0.066666f));
+	const int framesPerMin = fpsRound * 60 - dropPerMin;
+	const int framesPer10Min = framesPerMin * 10 + dropPerMin;
+	const int totalMin = int(hours) * 60 + minutes;
+	return uint32_t(framesPer10Min) * uint32_t(totalMin / 10)
+		+ uint32_t(framesPerMin) * uint32_t(totalMin % 10)
+		+ uint32_t(seconds) * uint32_t(fpsRound)
+		+ frames;
+}
+} // namespace
+
+struct TimecodeToFrameNumberNode : NodeContext
+{
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		const Timecode* tc = params.GetPinValue<Timecode>(NOS_NAME_STATIC("Timecode"));
+		if (!tc)
+			return NOS_RESULT_FAILED;
+
+		float frameRate = *params.GetPinValue<float>(NOS_NAME_STATIC("FrameRateOverride"));
+		if (frameRate <= 0.0f)
+			frameRate = FrameRateFromTiming(params.RawParams, 60.0f);
+
+		const bool isNtscFamily =
+			std::abs(frameRate - 29.97f) < 0.05f ||
+			std::abs(frameRate - 59.94f) < 0.05f;
+		const bool effectiveDropFrame = tc->drop_frame() && isNtscFamily;
+
+		const uint32_t frameNumber = TCToFrameNumber(
+			tc->hours(), tc->minutes(), tc->seconds(), tc->frames(),
+			frameRate, effectiveDropFrame);
+		SetPinValue(NOS_NAME_STATIC("FrameNumber"), nos::Buffer::From(frameNumber));
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterTimecodeToFrameNumber(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("TimecodeToFrameNumber"), TimecodeToFrameNumberNode, fn)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Source/TimecodeToString.cpp
+++ b/Source/TimecodeToString.cpp
@@ -1,0 +1,37 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+
+#include <cstdio>
+#include <cstring>
+
+#include "nosMediaio/ANC_generated.h"
+
+namespace nos::mediaio
+{
+
+struct TimecodeToStringNode : NodeContext
+{
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		const Timecode* tc = params.GetPinValue<Timecode>(NOS_NAME_STATIC("Timecode"));
+		if (!tc)
+			return NOS_RESULT_FAILED;
+
+		char buf[16];
+		std::snprintf(buf, sizeof(buf), "%02u:%02u:%02u%c%02u",
+			unsigned(tc->hours()), unsigned(tc->minutes()), unsigned(tc->seconds()),
+			tc->drop_frame() ? ';' : ':', unsigned(tc->frames()));
+		SetPinValue(NOS_NAME_STATIC("TimecodeStr"), nos::Buffer(buf, std::strlen(buf) + 1));
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterTimecodeToString(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("TimecodeToString"), TimecodeToStringNode, fn)
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Source/Timing.hpp
+++ b/Source/Timing.hpp
@@ -1,0 +1,40 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#pragma once
+
+#include <cstdio>
+#include <string>
+
+#include <Nodos/Plugin.hpp>
+
+// Shared frame-rate helpers for nodes that derive a rate from the executing path's
+// timing (Record/Playback Clip and the timecode nodes).
+namespace nos::mediaio
+{
+
+// Frame rate (FPS) inferred from a path's fixed-step timing. The scheduler's
+// DeltaSeconds is the seconds-per-frame rational {x = numerator, y = denominator}
+// (e.g. {1001, 60000} == 59.94 FPS), so FPS = y/x. Variable-step paths, and fixed-step
+// paths with no nominal rate yet ({0, 0}), have no fixed rate; `fallback` is returned for
+// those - pass 0.0f for "unset" or a nominal default (e.g. 60.0f) to substitute.
+inline float FrameRateFromTiming(const nosNodeExecuteParams* params, float fallback = 0.0f)
+{
+	if (params->TimingInfo.TimingMode == NOS_EXECUTION_TIMING_MODE_FIXED_STEP)
+	{
+		const auto& ds = params->TimingInfo.FixedStepTiming.DeltaSeconds;
+		if (ds.x != 0 && ds.y != 0)
+			return float(double(ds.y) / double(ds.x));
+	}
+	return fallback;
+}
+
+// A frame rate formatted for display with 4 significant digits ("59.94", "60", "23.98") -
+// enough to tell the fractional NTSC rates from their integer neighbours.
+inline std::string FrameRateToString(float fps)
+{
+	char buf[16];
+	std::snprintf(buf, sizeof(buf), "%.4g", fps);
+	return std::string(buf);
+}
+
+} // namespace nos::mediaio

--- a/Source/WriteDPX.cpp
+++ b/Source/WriteDPX.cpp
@@ -1,0 +1,264 @@
+// Copyright MediaZ Teknoloji A.S. All Rights Reserved.
+
+#include <Nodos/Plugin.hpp>
+#include <nosSysVulkan/Helpers.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <string>
+#include <vector>
+
+#include <Nodos/Utils/Stopwatch.hpp>
+
+#include "nosMediaio/ANC_generated.h"
+#include "nosMediaio/Conversion_generated.h"
+#include "Dpx.h"
+#include "Timing.hpp"
+
+namespace nos::mediaio
+{
+
+// Maps a packed RGBPixelFormat to the DPX image element's channel count and bit depth.
+// The pixel bytes themselves are produced upstream by the Texture To Buffer node.
+static void DpxLayoutFromFormat(RGBPixelFormat fmt, dpx::ImageDesc& d)
+{
+	switch (fmt)
+	{
+	case RGBPixelFormat::RGBA16: d.Channels = 4; d.BitDepth = 16; break;
+	case RGBPixelFormat::RGB10:  d.Channels = 3; d.BitDepth = 10; break;
+	case RGBPixelFormat::RGB8:   d.Channels = 3; d.BitDepth = 8;  break;
+	case RGBPixelFormat::RGBA8:
+	default:                        d.Channels = 4; d.BitDepth = 8;  break;
+	}
+}
+
+// DPX transfer characteristic code for the curve the upstream node encoded with. Curves DPX
+// has no dedicated code for (sRGB, HLG, ST2084, S-Log3) are tagged USER_DEFINED.
+static uint8_t DpxTransferFromCurve(GammaCurve curve)
+{
+	switch (curve)
+	{
+	case GammaCurve::IDENTITY: return dpx::CHARACTERISTIC_LINEAR;
+	case GammaCurve::REC709:   return dpx::CHARACTERISTIC_ITUR709;
+	default:                   return dpx::CHARACTERISTIC_USER_DEFINED;
+	}
+}
+
+// DPX colorimetric specification (colour primaries) implied by the encode curve. sRGB and
+// Rec.709 share Rec.709 primaries; the linear, HDR and log curves carry no primaries by
+// themselves (and DPX has no Rec.2020 / S-Gamut code), so they are left undefined rather than
+// mislabelled. Note "Linear" is a transfer code only - it is not a valid colorimetric value.
+static uint8_t DpxColorimetricFromCurve(GammaCurve curve)
+{
+	switch (curve)
+	{
+	case GammaCurve::SRGB:
+	case GammaCurve::REC709: return dpx::CHARACTERISTIC_ITUR709;
+	default:                 return dpx::CHARACTERISTIC_UNDEFINED;
+	}
+}
+
+// Writes the input Buffer to disk as an uncompressed DPX sequence, one file per timecode,
+// while the Write pin is true. The pixels are produced upstream (Texture To Buffer +
+// download ring), so this node does no GPU work and no conversion: it maps the host-visible
+// buffer and writes the bytes after the DPX header. Resolution, Output Format and Transfer
+// pins describe the buffer for the header - they must match the upstream Texture To Buffer
+// node. Execution is driven through the In/Out exe pins. Progress and errors are surfaced on
+// the node status.
+struct WriteDPXNode : NodeContext
+{
+	// Status is split across a few short lines instead of one long string. Each slot is
+	// updated independently; the set is pushed to the engine only when it actually changes
+	// (see FlushStatus), so a steadily-writing node does not touch the engine every frame.
+	enum class StatusSlot : int { State = 0, Format = 1, Path = 2, Frames = 3 };
+	std::map<StatusSlot, fb::TNodeStatusMessage> StatusMessages;
+	bool StatusDirty = false;
+
+	bool WasWriting = false;
+	uint64_t WrittenFrames = 0;
+
+	// Refresh the live frame count every this many frames rather than every frame.
+	static constexpr uint64_t FrameStatusInterval = 30;
+
+
+	void SetStatus(StatusSlot slot, fb::NodeStatusMessageType type, std::string text)
+	{
+		auto it = StatusMessages.find(slot);
+		if (it != StatusMessages.end() && it->second.type == type && it->second.text == text)
+			return; // unchanged - leave the dirty flag alone
+		StatusMessages[slot] = fb::TNodeStatusMessage{ {}, std::move(text), type };
+		StatusDirty = true;
+	}
+
+	void ClearStatus(StatusSlot slot)
+	{
+		if (StatusMessages.erase(slot))
+			StatusDirty = true;
+	}
+
+	// Pushes the message set to the engine only when it changed (map order = display order).
+	void FlushStatus()
+	{
+		if (!StatusDirty)
+			return;
+		std::vector<fb::TNodeStatusMessage> messages;
+		messages.reserve(StatusMessages.size());
+		for (auto& [slot, msg] : StatusMessages)
+			messages.push_back(msg);
+		SetNodeStatusMessages(messages);
+		StatusDirty = false;
+	}
+
+	nosResult ExecuteNode(NodeExecuteParams const& params) override
+	{
+		// Per-section timing surfaced on the watch panel as "<node> <section>".
+		nos::util::Stopwatch total, section;
+		auto lap = [&](const char* name) {
+			nosEngine.WatchLog((NodeName.AsString() + " " + name).c_str(),
+				section.ElapsedStringAndReset().c_str());
+		};
+
+		// Destination directory - shown on the status whether or not we are writing.
+		const char* pathC = params.GetPinValue<const char*>(NOS_NAME_STATIC("Path"));
+		if (!pathC)
+			pathC = "";
+		if (!*pathC)
+		{
+			ClearStatus(StatusSlot::State);
+			ClearStatus(StatusSlot::Format);
+			ClearStatus(StatusSlot::Frames);
+			SetStatus(StatusSlot::Path, fb::NodeStatusMessageType::WARNING, "Destination path not set");
+			FlushStatus();
+			return NOS_RESULT_SUCCESS;
+		}
+		SetStatus(StatusSlot::Path, fb::NodeStatusMessageType::INFO, pathC);
+
+		const bool* write = params.GetPinValue<bool>(NOS_NAME_STATIC("Write"));
+		bool writing = write && *write;
+		if (writing && !WasWriting)
+			WrittenFrames = 0; // rising edge: restart the frame count
+		WasWriting = writing;
+		if (!writing)
+		{
+			ClearStatus(StatusSlot::Format);
+			ClearStatus(StatusSlot::Frames);
+			SetStatus(StatusSlot::State, fb::NodeStatusMessageType::INFO, "Idle");
+			FlushStatus();
+			return NOS_RESULT_SUCCESS;
+		}
+
+		// Surfaces a failure on the State line and stops.
+		auto fail = [&](std::string text) {
+			ClearStatus(StatusSlot::Format);
+			ClearStatus(StatusSlot::Frames);
+			SetStatus(StatusSlot::State, fb::NodeStatusMessageType::FAILURE, std::move(text));
+			FlushStatus();
+			return NOS_RESULT_FAILED;
+		};
+
+		const Timecode* tc = params.GetPinValue<Timecode>(NOS_NAME_STATIC("Timecode"));
+		if (!tc)
+			return fail("Missing Timecode input");
+
+		const nosVec2u* resolution = params.GetPinValue<nosVec2u>(NOS_NAME_STATIC("Resolution"));
+		if (!resolution || !resolution->x || !resolution->y)
+			return fail("Set Resolution to the buffer's frame size");
+
+		auto fmt = RGBPixelFormat::RGBA8;
+		if (auto* f = params.GetPinValue<RGBPixelFormat>(NOS_NAME_STATIC("OutputFormat")))
+			fmt = *f;
+		GammaCurve curve = GammaCurve::SRGB;
+		if (auto* c = params.GetPinValue<GammaCurve>(NOS_NAME_STATIC("Transfer")))
+			curve = *c;
+
+		dpx::ImageDesc desc{};
+		desc.Width = resolution->x;
+		desc.Height = resolution->y;
+		DpxLayoutFromFormat(fmt, desc);
+		desc.Transfer = DpxTransferFromCurve(curve);
+		desc.Colorimetric = DpxColorimetricFromCurve(curve);
+		uint64_t dataSize = dpx::ImageDataSize(desc);
+		lap("Setup");
+
+		// The pixels are already on the host (download ring upstream); just map and read them.
+		auto buf = params.GetPinObject<sys::vulkan::Buffer>(NOS_NAME_STATIC("Buffer"));
+		auto bufInfo = sys::vulkan::GetResourceInfo(buf);
+		if (!buf.IsValid() || !bufInfo)
+		{
+			ClearStatus(StatusSlot::Format);
+			ClearStatus(StatusSlot::Frames);
+			SetStatus(StatusSlot::State, fb::NodeStatusMessageType::WARNING, "Waiting for input buffer");
+			FlushStatus();
+			return NOS_RESULT_SUCCESS;
+		}
+		if (bufInfo->Size < dataSize)
+		{
+			nosEngine.LogE("WriteDPX: buffer (%llu bytes) smaller than the frame needs (%llu bytes) "
+				"- check Resolution and Output Format", (unsigned long long)bufInfo->Size,
+				(unsigned long long)dataSize);
+			return fail("Buffer smaller than frame - check Resolution / Output Format");
+		}
+
+		uint8_t* pixels = nosVulkan->Map(buf);
+		if (!pixels)
+		{
+			nosEngine.LogE("WriteDPX: failed to map input buffer");
+			return fail("Failed to map input buffer");
+		}
+		lap("Map");
+
+		std::filesystem::path dir = nos::Utf8ToPath(std::string(pathC));
+		std::string fileName = dpx::TimecodeToFileName(*tc);
+		std::filesystem::path filePath = dir / fileName;
+		try
+		{
+			std::filesystem::create_directories(dir);
+		}
+		catch (const std::filesystem::filesystem_error& e)
+		{
+			nosEngine.LogE("WriteDPX: %s: %s", nos::PathToUtf8(dir).c_str(), e.what());
+			return fail("Cannot create output directory");
+		}
+
+		// Frame rate for the DPX header: infer from the path's fixed-step timing; variable-step
+		// paths have no nominal rate, so leave it unset (0).
+		float frameRate = FrameRateFromTiming(params.RawParams);
+
+		uint8_t header[dpx::HEADER_SIZE];
+		dpx::WriteHeader(header, desc, *tc, frameRate);
+
+		std::ofstream file(filePath, std::ios::binary | std::ios::trunc);
+		if (!file
+			|| !file.write(reinterpret_cast<const char*>(header), dpx::HEADER_SIZE)
+			|| !file.write(reinterpret_cast<const char*>(pixels), std::streamsize(dataSize)))
+		{
+			nosEngine.LogE("WriteDPX: failed to write %s", nos::PathToUtf8(filePath).c_str());
+			return fail("Failed to write " + fileName);
+		}
+		lap("DiskWrite");
+		nosEngine.WatchLog((NodeName.AsString() + " | Total").c_str(), total.ElapsedString().c_str());
+
+		++WrittenFrames;
+		SetStatus(StatusSlot::State, fb::NodeStatusMessageType::INFO, "Writing");
+		// "1920x1080 @59.94 FPS" (FPS dropped on variable-step paths) - stable while writing.
+		std::string format = std::to_string(desc.Width) + "x" + std::to_string(desc.Height);
+		if (frameRate > 0.0f)
+			format += " @" + FrameRateToString(frameRate) + " FPS";
+		SetStatus(StatusSlot::Format, fb::NodeStatusMessageType::INFO, std::move(format));
+		// Only refresh the count periodically so we are not flushing status every frame.
+		if (WrittenFrames == 1 || WrittenFrames % FrameStatusInterval == 0)
+			SetStatus(StatusSlot::Frames, fb::NodeStatusMessageType::INFO,
+				std::to_string(WrittenFrames) + " frames");
+		FlushStatus();
+		return NOS_RESULT_SUCCESS;
+	}
+};
+
+nosResult RegisterWriteDPX(nosNodeFunctions* fn)
+{
+	NOS_BIND_NODE_CLASS(NOS_NAME_STATIC("WriteDPX"), WriteDPXNode, fn);
+	return NOS_RESULT_SUCCESS;
+}
+
+} // namespace nos::mediaio

--- a/Types/ANC.fbs
+++ b/Types/ANC.fbs
@@ -1,0 +1,103 @@
+namespace nos.mediaio;
+
+// SMPTE 291M ancillary data space.
+enum ANCDataSpace : uint
+{
+    Unknown = 0,
+    HANC = 1,
+    VANC = 2,
+}
+
+// Which video stream component a packet was carried in.
+enum ANCDataChannel : uint
+{
+    Both = 0, // Packet is component-agnostic / unknown
+    Y = 1,    // Luma
+    C = 2,    // Chroma
+}
+
+// Dual-link / quad-link physical link (A=primary, B=secondary).
+enum ANCDataLink : uint
+{
+    Unknown = 0,
+    A = 1,
+    B = 2,
+}
+
+// SDI sub-stream identifier in multi-stream signals (quad-link 4K, 12G-SDI).
+// Orthogonal to ANCDataLink (which selects the dual-link 1.5G physical link).
+enum ANCDataStream : uint
+{
+    Unknown = 0,
+    DS1 = 1,
+    DS2 = 2,
+    DS3 = 3,
+    DS4 = 4,
+}
+
+// SMPTE 291 coding type. Mirrors AJAAncDataCoding in the AJA SDK.
+// Digital is the SMPTE-291 packet format used on nearly all SDI/2110 ANC;
+// Raw is for digitized analog waveforms (CEA-608 captions, VITC) typically
+// captured from HDMI ingest paths.
+enum ANCDataCoding : ubyte
+{
+    Digital = 0,
+    Raw = 1,
+    Unknown = 2,
+}
+
+// A single SMPTE 291 ancillary data packet.
+// Variable-length payload (DC = payload.size()) — flatbuffers requires a table for this.
+table ANCPacket
+{
+    did: ubyte;            // Data ID (0x00..0xFF)
+    sdid: ubyte;           // Secondary Data ID
+    line_number: uint16;   // SMPTE line number; 0 if unspecified
+    horiz_offset: uint16;  // SMPTE-291 horizontal offset (0 = anywhere)
+    space: ANCDataSpace;
+    channel: ANCDataChannel;
+    link: ANCDataLink;
+    stream: ANCDataStream; // Logical SDI sub-stream (DS1..DS4) in quad-link / 12G
+    is_field2: bool;       // True if this packet belongs to field 2 (interlaced sources)
+    coding: ANCDataCoding = Digital; // SMPTE-291 coding type; default Digital so pre-existing buffers decode unchanged.
+    payload: [ubyte];      // SMPTE 291 user data words, one per byte
+}
+
+// All ancillary packets captured/destined for a single video frame.
+table ANCFrame
+{
+    packets: [ANCPacket];
+}
+
+// SMPTE ST 12-2 Ancillary Timecode flavor selector. Encoded in DBB1 bits 2-0
+// of the ATC packet (DID=0x60, SDID=0x60).
+enum ATCSource : uint
+{
+    Auto = 0,    // Pick the first valid ATC packet found, preferring LTC.
+    ATC_LTC = 1,
+    ATC_VITC1 = 2,
+    ATC_VITC2 = 3,
+}
+
+// Decoded SMPTE timecode. Self-contained — no frame number, no frame rate;
+// senders and receivers agree on rate via the executing path's fixed-step
+// timing or an explicit rate-override pin. Convert to/from a frame number
+// with TimecodeFromFrameNumber / TimecodeToFrameNumber.
+struct Timecode
+{
+    hours: ubyte;       // 0..23
+    minutes: ubyte;     // 0..59
+    seconds: ubyte;     // 0..59
+    // 0..(fpsRound-1). For high frame rates (>=40 fps) this is the full
+    // 0..59 value, not the wire-halved 0..30 that ST 12-1 carries on a
+    // single ATC packet.
+    frames: ubyte;
+    // Drop-frame flag. Only defined for 29.97/59.94; ignored at integer
+    // rates by consumers that follow ST 12-1.
+    drop_frame: bool;
+    // ATC carriage. ATC_LTC / ATC_VITC1 / ATC_VITC2 select what DBB1 bits 2-0
+    // are encoded as. Auto means "pick the best available" on read; on write
+    // it is treated as ATC_LTC. Flatbuffers struct fields cannot have default
+    // values — the .nosdef defaults handle initial pin state instead.
+    source: ATCSource;
+}

--- a/Types/Conversion.fbs
+++ b/Types/Conversion.fbs
@@ -6,6 +6,8 @@ enum ColorSpace : uint {
     REC709  = 0,
     REC601  = 1,
     REC2020 = 2,
+    SGAMUT3 = 3,
+    SGAMUT3CINE = 4,
 }
 
 // must match GammaFunctions.glsl
@@ -15,6 +17,7 @@ enum GammaCurve : uint {
     ST2084 = 2,
     SRGB = 3,
     IDENTITY = 4,
+    SLOG3 = 5,
 }
 
 enum GammaConversionType : uint {
@@ -30,7 +33,22 @@ enum InterlacedFlags : uint(bit_flags) {
     INPUT_ODD = 3,
 }
 
+// TODO: Merge YCbCrPixelFormat and RGBPixelFormat into a single PixelFormat enum covering
+// both the YCbCr and RGB packed layouts, and migrate the conversion nodes to it.
 enum YCbCrPixelFormat: uint {
     YUV8,
     V210
+}
+
+// Packed pixel layout TextureToBuffer writes into its output buffer (and RecordClip
+// writes to disk). Must match the PIXEL_FORMAT_* defines in TextureToBuffer.comp.
+//   RGBA8  - 4 channels,  8-bit, one 32-bit word per pixel
+//   RGBA16 - 4 channels, 16-bit, two 32-bit words per pixel
+//   RGB10  - 3 channels, 10-bit, DPX Method A (R[31:22] G[21:12] B[11:2], 2 pad bits)
+//   RGB8   - 3 channels,  8-bit, tightly packed (3 bytes per pixel)
+enum RGBPixelFormat : uint {
+    RGBA8,
+    RGBA16,
+    RGB10,
+    RGB8
 }

--- a/Types/Conversion.fbs
+++ b/Types/Conversion.fbs
@@ -8,6 +8,7 @@ enum ColorSpace : uint {
     REC2020 = 2,
 }
 
+// must match GammaFunctions.glsl
 enum GammaCurve : uint {
     REC709  = 0,
     HLG  = 1,

--- a/Types/TimecodePlayer.fbs
+++ b/Types/TimecodePlayer.fbs
@@ -1,0 +1,7 @@
+namespace nos.mediaio;
+
+enum TimecodePlayerMode : uint
+{
+    Ranged = 0,      // Play from Start Time to End Timecode, then stop.
+    Continuous = 1,  // Count up from Start Time; End Timecode ignored.
+}


### PR DESCRIPTION
Cherry-picks recent nodos-1.3 changes onto dev, conformed to the Nodos 1.4 SDK (41) and Vulkan 8.0 (vkss::Resource -> sys::vulkan resource-object API, GetPinData -> GetPinValue, node constructors -> OnCreate, nosdefs -> nosnodes).

Included:
- Add video connection type enum to the merged Media I/O API.
- Gamma-curve option (UseLUT/GammaCurve) for the RGB-YCbCr conversion nodes.
- Hide Deinterlace/Interlace nodes from the context menu and warn on use.
- Filmmaking nodes and types: ANC data, Timecode (parse/edit/player/convert), and DPX sequence read/write.
- Fix UseLUT not honored on the YCbCr2RGB (decode) path.
